### PR TITLE
feat: Add Live Preview editable tags support (addEditableTags/addTags)

### DIFF
--- a/Contentstack.Utils.Tests/LivePreviewTagsTest.cs
+++ b/Contentstack.Utils.Tests/LivePreviewTagsTest.cs
@@ -1,0 +1,596 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+using Contentstack.Utils.Models;
+using Contentstack.Utils.Interfaces;
+using Newtonsoft.Json.Linq;
+using System.IO;
+
+namespace Contentstack.Utils.Tests
+{
+    /// <summary>
+    /// Comprehensive test suite for Live Preview editable tags functionality.
+    /// Tests match the JavaScript SDK test patterns for complete parity.
+    /// </summary>
+    public class LivePreviewTagsTest
+    {
+        #region Test Data and Helpers
+
+        private static JObject ReadJsonRoot(string fileName)
+        {
+            var path = Path.Combine(AppContext.BaseDirectory, "Resources", fileName);
+            return JObject.Parse(File.ReadAllText(path));
+        }
+
+        private Dictionary<string, object> CreateBasicEntry()
+        {
+            return new Dictionary<string, object>
+            {
+                ["_version"] = 10,
+                ["locale"] = "en-us",
+                ["uid"] = "entry_uid_1",
+                ["ACL"] = new Dictionary<string, object>(),
+                ["rich_text_editor"] = "<p>Content with text</p>",
+                ["rich_text_editor_multiple"] = new List<object> { "<p>Multiple content</p>" }
+            };
+        }
+
+        private Dictionary<string, object> CreateModularBlockEntry()
+        {
+            return new Dictionary<string, object>
+            {
+                ["_version"] = 10,
+                ["locale"] = "en-us",
+                ["uid"] = "entry_uid_1",
+                ["ACL"] = new Dictionary<string, object>(),
+                ["modular_blocks"] = new object[]
+                {
+                    new Dictionary<string, object>
+                    {
+                        ["rich_text_inmodular"] = new Dictionary<string, object>
+                        {
+                            ["rich_text_editor"] = "<p>Modular content 1</p>",
+                            ["rich_text_editor_multiple"] = new List<object> { "<p>Modular multiple 1</p>" },
+                            ["_metadata"] = new Dictionary<string, object> { ["uid"] = "metadata_uid_1" }
+                        }
+                    },
+                    new Dictionary<string, object>
+                    {
+                        ["global_modular"] = new Dictionary<string, object>
+                        {
+                            ["rich_text_editor"] = "<p>Global modular content</p>",
+                            ["rich_text_editor_multiple"] = new List<object> { "<p>Global modular multiple</p>" },
+                            ["group"] = new Dictionary<string, object>
+                            {
+                                ["rich_text_editor"] = "<p>Nested group content</p>",
+                                ["rich_text_editor_multiple"] = new List<object> { "<p>Nested group multiple</p>" }
+                            },
+                            ["_metadata"] = new Dictionary<string, object> { ["uid"] = "metadata_uid_2" }
+                        }
+                    }
+                }
+            };
+        }
+
+        private Dictionary<string, object> CreateReferenceEntry()
+        {
+            return new Dictionary<string, object>
+            {
+                ["_version"] = 10,
+                ["locale"] = "en-us",
+                ["uid"] = "entry_uid_1",
+                ["ACL"] = new Dictionary<string, object>(),
+                ["reference"] = new object[]
+                {
+                    new Dictionary<string, object>
+                    {
+                        ["uid"] = "entry_uid_11",
+                        ["_content_type_uid"] = "embed_entry",
+                        ["title"] = "Reference Entry Title",
+                        ["rich_text_editor"] = "<p>Reference content</p>",
+                        ["rich_text_editor_multiple"] = new List<object> { "<p>Reference multiple</p>" }
+                    }
+                }
+            };
+        }
+
+        private Dictionary<string, object> CreateVariantEntry()
+        {
+            return new Dictionary<string, object>
+            {
+                ["_version"] = 10,
+                ["locale"] = "en-us",
+                ["uid"] = "entry_uid_1",
+                ["ACL"] = new Dictionary<string, object>(),
+                ["_applied_variants"] = new Dictionary<string, object>
+                {
+                    ["rich_text_editor"] = "variant_1",
+                    ["nested.field"] = "variant_2",
+                    ["modular_blocks.content_from_variant.metadata_uid_2"] = "variant_3"
+                },
+                ["rich_text_editor"] = "<p>Content with variant</p>",
+                ["rich_text_editor_multiple"] = new List<object> { "<p>Multiple content</p>" },
+                ["nested"] = new Dictionary<string, object>
+                {
+                    ["field"] = "nested field content",
+                    ["other_field"] = "other nested content"
+                }
+            };
+        }
+
+        private EditableEntryMock CreateEditableEntry(Dictionary<string, object> data)
+        {
+            return new EditableEntryMock(data);
+        }
+
+        /// <summary>
+        /// Mock implementation of EditableEntry for testing purposes.
+        /// </summary>
+        public class EditableEntryMock : EditableEntry
+        {
+            private readonly Dictionary<string, object> _data;
+
+            public EditableEntryMock(Dictionary<string, object> data)
+            {
+                _data = new Dictionary<string, object>(data);
+            }
+
+            public string Uid 
+            { 
+                get => _data.ContainsKey("uid") ? _data["uid"]?.ToString() : null;
+                set => _data["uid"] = value;
+            }
+
+            public string ContentTypeUid 
+            { 
+                get => _data.ContainsKey("_content_type_uid") ? _data["_content_type_uid"]?.ToString() : null;
+                set => _data["_content_type_uid"] = value;
+            }
+
+            public string Title 
+            { 
+                get => _data.ContainsKey("title") ? _data["title"]?.ToString() : null;
+                set => _data["title"] = value;
+            }
+
+            public string Locale 
+            { 
+                get => _data.ContainsKey("locale") ? _data["locale"]?.ToString() : null;
+                set => _data["locale"] = value;
+            }
+
+            public object this[string key]
+            {
+                get => _data.ContainsKey(key) ? _data[key] : null;
+                set => _data[key] = value;
+            }
+
+            public Dictionary<string, object> GetData() => _data;
+
+            // Add ContainsKey method for extensions
+            public bool ContainsKey(string key) => _data.ContainsKey(key);
+        }
+
+        #endregion
+
+        #region Basic Functionality Tests
+
+        [Fact]
+        public void AddEditableTags_BasicEntry_StringTags_GeneratesCorrectTags()
+        {
+            // Arrange
+            var entry = CreateEditableEntry(CreateBasicEntry());
+
+            // Act
+            Utils.addEditableTags(entry, "entry_asset", false);
+
+            // Debug output
+            var dollarKey = entry["$"];
+            Assert.NotNull(dollarKey); // First check if $ key exists
+            
+            var tags = (Dictionary<string, object>)dollarKey;
+            Assert.NotNull(tags); // Check if tags object exists
+            Assert.True(tags.Count > 0); // Check if tags has any entries
+            
+            // Assert the specific tags exist
+            Assert.True(tags.ContainsKey("rich_text_editor"), $"Missing rich_text_editor key. Available keys: {string.Join(", ", tags.Keys)}");
+            Assert.Equal("data-cslp=entry_asset.entry_uid_1.en-us.rich_text_editor", tags["rich_text_editor"]);
+            Assert.Equal("data-cslp=entry_asset.entry_uid_1.en-us.rich_text_editor_multiple", tags["rich_text_editor_multiple"]);
+        }
+
+        [Fact]
+        public void AddEditableTags_BasicEntry_ObjectTags_GeneratesCorrectTags()
+        {
+            // Arrange
+            var entry = CreateEditableEntry(CreateBasicEntry());
+
+            // Act
+            Utils.addEditableTags(entry, "entry_asset", true);
+
+            // Assert
+            var tags = (Dictionary<string, object>)entry["$"];
+            var richTextTag = (Dictionary<string, object>)tags["rich_text_editor"];
+            var richTextMultipleTag = (Dictionary<string, object>)tags["rich_text_editor_multiple"];
+
+            Assert.Equal("entry_asset.entry_uid_1.en-us.rich_text_editor", richTextTag["data-cslp"]);
+            Assert.Equal("entry_asset.entry_uid_1.en-us.rich_text_editor_multiple", richTextMultipleTag["data-cslp"]);
+        }
+
+        [Fact]
+        public void AddEditableTags_NullEntry_DoesNotThrow()
+        {
+            // Act & Assert - should not throw
+            Utils.addEditableTags(null, "entry_asset", false);
+        }
+
+        [Fact]
+        public void AddEditableTags_EmptyEntry_DoesNotThrow()
+        {
+            // Arrange
+            var entry = CreateEditableEntry(new Dictionary<string, object> { ["uid"] = "test", ["locale"] = "en-us" });
+
+            // Act & Assert - should not throw
+            Utils.addEditableTags(entry, "entry_asset", false);
+            
+            // Should have empty tags object
+            var tags = (Dictionary<string, object>)entry["$"];
+            Assert.NotNull(tags);
+        }
+
+        #endregion
+
+        #region Modular Block Tests
+
+        [Fact]
+        public void AddEditableTags_ModularBlocks_StringTags_GeneratesCorrectNestedTags()
+        {
+            // Arrange
+            var entry = CreateEditableEntry(CreateModularBlockEntry());
+
+            // Act
+            Utils.addEditableTags(entry, "entry_multiple_content", false);
+
+            // Assert - Check deeply nested modular block tags
+            var modularBlocks = (object[])entry.GetData()["modular_blocks"];
+            var firstBlock = (Dictionary<string, object>)modularBlocks[0];
+            var richTextInModular = (Dictionary<string, object>)firstBlock["rich_text_inmodular"];
+            var tags = (Dictionary<string, object>)richTextInModular["$"];
+
+            Assert.Equal("data-cslp=entry_multiple_content.entry_uid_1.en-us.modular_blocks.0.rich_text_inmodular.rich_text_editor", 
+                tags["rich_text_editor"]);
+            Assert.Equal("data-cslp=entry_multiple_content.entry_uid_1.en-us.modular_blocks.0.rich_text_inmodular.rich_text_editor_multiple", 
+                tags["rich_text_editor_multiple"]);
+        }
+
+        [Fact]
+        public void AddEditableTags_ModularBlocks_ObjectTags_GeneratesCorrectNestedTags()
+        {
+            // Arrange
+            var entry = CreateEditableEntry(CreateModularBlockEntry());
+
+            // Act
+            Utils.addEditableTags(entry, "entry_multiple_content", true);
+
+            // Assert - Check object format for nested tags
+            var modularBlocks = (object[])entry.GetData()["modular_blocks"];
+            var secondBlock = (Dictionary<string, object>)modularBlocks[1];
+            var globalModular = (Dictionary<string, object>)secondBlock["global_modular"];
+            var tags = (Dictionary<string, object>)globalModular["$"];
+            var richTextTag = (Dictionary<string, object>)tags["rich_text_editor"];
+
+            Assert.Equal("entry_multiple_content.entry_uid_1.en-us.modular_blocks.1.global_modular.rich_text_editor", 
+                richTextTag["data-cslp"]);
+        }
+
+        #endregion
+
+        #region Reference Entry Tests
+
+        [Fact]
+        public void AddEditableTags_ReferenceEntry_StringTags_UsesReferenceContentType()
+        {
+            // Arrange
+            var entry = CreateEditableEntry(CreateReferenceEntry());
+
+            // Act
+            Utils.addEditableTags(entry, "entry_asset", false);
+
+            // Assert - Reference should use its own content type
+            var reference = (object[])entry.GetData()["reference"];
+            var refEntry = (Dictionary<string, object>)reference[0];
+            var tags = (Dictionary<string, object>)refEntry["$"];
+
+            Assert.Equal("data-cslp=embed_entry.entry_uid_11.en-us.rich_text_editor", tags["rich_text_editor"]);
+            Assert.Equal("data-cslp=embed_entry.entry_uid_11.en-us.rich_text_editor_multiple", tags["rich_text_editor_multiple"]);
+        }
+
+        [Fact]
+        public void AddEditableTags_ReferenceEntry_ObjectTags_UsesReferenceContentType()
+        {
+            // Arrange
+            var entry = CreateEditableEntry(CreateReferenceEntry());
+
+            // Act
+            Utils.addEditableTags(entry, "entry_asset", true);
+
+            // Assert - Reference should use its own content type in object format
+            var reference = (object[])entry.GetData()["reference"];
+            var refEntry = (Dictionary<string, object>)reference[0];
+            var tags = (Dictionary<string, object>)refEntry["$"];
+            var richTextTag = (Dictionary<string, object>)tags["rich_text_editor"];
+
+            Assert.Equal("embed_entry.entry_uid_11.en-us.rich_text_editor", richTextTag["data-cslp"]);
+        }
+
+        #endregion
+
+        #region Array Processing Tests
+
+        [Fact]
+        public void AddEditableTags_ArrayWithNullElements_SkipsNullElements()
+        {
+            // Arrange
+            var entryData = new Dictionary<string, object>
+            {
+                ["locale"] = "en-us",
+                ["uid"] = "uid",
+                ["items"] = new object[] 
+                { 
+                    null, 
+                    new Dictionary<string, object> { ["title"] = "valid item" }, 
+                    null 
+                }
+            };
+            var entry = CreateEditableEntry(entryData);
+
+            // Act & Assert - should not throw
+            Utils.addEditableTags(entry, "content_type", false);
+
+            // Check that valid item got tagged
+            var items = (object[])entry.GetData()["items"];
+            var validItem = (Dictionary<string, object>)items[1];
+            var tags = (Dictionary<string, object>)validItem["$"];
+            
+            Assert.Equal("data-cslp=content_type.uid.en-us.items.1.title", tags["title"]);
+        }
+
+        [Fact]
+        public void AddEditableTags_ArrayElements_GeneratesIndexAndParentTags()
+        {
+            // Arrange
+            var entryData = new Dictionary<string, object>
+            {
+                ["locale"] = "en-us",
+                ["uid"] = "uid",
+                ["items"] = new object[] 
+                { 
+                    new Dictionary<string, object> { ["title"] = "item 1" },
+                    new Dictionary<string, object> { ["title"] = "item 2" }
+                }
+            };
+            var entry = CreateEditableEntry(entryData);
+
+            // Act
+            Utils.addEditableTags(entry, "content_type", false);
+
+            // Assert - Check field__index and field__parent patterns
+            var tags = (Dictionary<string, object>)entry["$"];
+            
+            Assert.Contains("items__0", tags.Keys);
+            Assert.Contains("items__1", tags.Keys);
+            Assert.Contains("items__parent", tags.Keys);
+            
+            Assert.Equal("data-cslp=content_type.uid.en-us.items.0", tags["items__0"]);
+            Assert.Equal("data-cslp=content_type.uid.en-us.items.1", tags["items__1"]);
+            Assert.Equal("data-cslp-parent-field=content_type.uid.en-us.items", tags["items__parent"]);
+        }
+
+        #endregion
+
+        #region Variant Support Tests
+
+        [Fact]
+        public void AddEditableTags_WithVariants_StringTags_AppliesV2PrefixAndVariantSuffix()
+        {
+            // Arrange
+            var entry = CreateEditableEntry(CreateVariantEntry());
+
+            // Act
+            Utils.addEditableTags(entry, "entry_asset", false);
+
+            // Assert - Field with direct variant match should get v2 prefix and variant suffix
+            var tags = (Dictionary<string, object>)entry["$"];
+            Assert.Equal("data-cslp=v2:entry_asset.entry_uid_1_variant_1.en-us.rich_text_editor", tags["rich_text_editor"]);
+            
+            // Field without variant should not have v2 prefix
+            Assert.Equal("data-cslp=entry_asset.entry_uid_1.en-us.rich_text_editor_multiple", tags["rich_text_editor_multiple"]);
+        }
+
+        [Fact]
+        public void AddEditableTags_WithVariants_ObjectTags_AppliesV2PrefixAndVariantSuffix()
+        {
+            // Arrange
+            var entry = CreateEditableEntry(CreateVariantEntry());
+
+            // Act
+            Utils.addEditableTags(entry, "entry_asset", true);
+
+            // Assert - Field with direct variant match should get v2 prefix and variant suffix as object
+            var tags = (Dictionary<string, object>)entry["$"];
+            var richTextTag = (Dictionary<string, object>)tags["rich_text_editor"];
+            var richTextMultipleTag = (Dictionary<string, object>)tags["rich_text_editor_multiple"];
+
+            Assert.Equal("v2:entry_asset.entry_uid_1_variant_1.en-us.rich_text_editor", richTextTag["data-cslp"]);
+            Assert.Equal("entry_asset.entry_uid_1.en-us.rich_text_editor_multiple", richTextMultipleTag["data-cslp"]);
+        }
+
+        [Fact]
+        public void AddEditableTags_WithNestedVariants_AppliesCorrectVariants()
+        {
+            // Arrange
+            var entry = CreateEditableEntry(CreateVariantEntry());
+
+            // Act
+            Utils.addEditableTags(entry, "entry_asset", false);
+
+            // Assert - Nested field with direct variant match
+            var nested = (Dictionary<string, object>)entry.GetData()["nested"];
+            var nestedTags = (Dictionary<string, object>)nested["$"];
+            
+            Assert.Equal("data-cslp=v2:entry_asset.entry_uid_1_variant_2.en-us.nested.field", nestedTags["field"]);
+            Assert.Equal("data-cslp=entry_asset.entry_uid_1.en-us.nested.other_field", nestedTags["other_field"]);
+        }
+
+        [Fact]
+        public void AddEditableTags_EmptyVariants_WorksNormally()
+        {
+            // Arrange
+            var entryData = CreateBasicEntry();
+            entryData["_applied_variants"] = new Dictionary<string, object>(); // Empty variants
+            var entry = CreateEditableEntry(entryData);
+
+            // Act
+            Utils.addEditableTags(entry, "entry_asset", false);
+
+            // Assert - Should not have v2 prefix when variants object is empty
+            var tags = (Dictionary<string, object>)entry["$"];
+            Assert.Equal("data-cslp=entry_asset.entry_uid_1.en-us.rich_text_editor", tags["rich_text_editor"]);
+        }
+
+        #endregion
+
+        #region Locale and Case Sensitivity Tests
+
+        [Fact]
+        public void AddEditableTags_UseLowerCaseLocaleTrue_LowercasesLocale()
+        {
+            // Arrange
+            var entry = CreateEditableEntry(CreateBasicEntry());
+            var options = new AddEditableTagsOptions { UseLowerCaseLocale = true };
+
+            // Act
+            Utils.addEditableTags(entry, "TEST_CONTENT_TYPE", false, "en-US", options);
+
+            // Assert - Both content type and locale should be lowercased
+            var tags = (Dictionary<string, object>)entry["$"];
+            var tag = (string)tags["rich_text_editor"];
+            Assert.Contains("test_content_type.entry_uid_1.en-us.rich_text_editor", tag);
+        }
+
+        [Fact]
+        public void AddEditableTags_UseLowerCaseLocaleFalse_PreservesLocaleCase()
+        {
+            // Arrange
+            var entry = CreateEditableEntry(CreateBasicEntry());
+            var options = new AddEditableTagsOptions { UseLowerCaseLocale = false };
+
+            // Act
+            Utils.addEditableTags(entry, "TEST_CONTENT_TYPE", false, "en-US", options);
+
+            // Assert - Content type lowercased but locale case preserved
+            var tags = (Dictionary<string, object>)entry["$"];
+            var tag = (string)tags["rich_text_editor"];
+            Assert.Contains("test_content_type.entry_uid_1.en-US.rich_text_editor", tag);
+        }
+
+        [Fact]
+        public void AddEditableTags_DefaultOptions_LowercasesLocale()
+        {
+            // Arrange
+            var entry = CreateEditableEntry(CreateBasicEntry());
+
+            // Act
+            Utils.addEditableTags(entry, "TEST_CONTENT_TYPE", false, "en-US");
+
+            // Assert - Default behavior should lowercase locale
+            var tags = (Dictionary<string, object>)entry["$"];
+            var tag = (string)tags["rich_text_editor"];
+            Assert.Contains("test_content_type.entry_uid_1.en-us.rich_text_editor", tag);
+        }
+
+        #endregion
+
+        #region Alias Method Tests
+
+        [Fact]
+        public void AddTags_Alias_WorksCorrectly()
+        {
+            // Arrange
+            var entry = CreateEditableEntry(CreateBasicEntry());
+
+            // Act
+            Utils.addTags(entry, "entry_asset", false);
+
+            // Assert - Should work identically to addEditableTags
+            var tags = (Dictionary<string, object>)entry["$"];
+            Assert.Equal("data-cslp=entry_asset.entry_uid_1.en-us.rich_text_editor", tags["rich_text_editor"]);
+        }
+
+        #endregion
+
+        #region Error Handling and Edge Cases
+
+        [Fact]
+        public void AddEditableTags_NullFieldValue_DoesNotThrow()
+        {
+            // Arrange
+            var entryData = new Dictionary<string, object>
+            {
+                ["uid"] = "entry_uid_null",
+                ["locale"] = "en-us",
+                ["title"] = "Valid title",
+                ["description"] = null
+            };
+            var entry = CreateEditableEntry(entryData);
+
+            // Act & Assert - should not throw
+            Utils.addEditableTags(entry, "content_type", false);
+            
+            var tags = (Dictionary<string, object>)entry["$"];
+            Assert.Equal("data-cslp=content_type.entry_uid_null.en-us.title", tags["title"]);
+        }
+
+        [Fact]
+        public void AddEditableTags_ComplexNestedStructure_HandlesGracefully()
+        {
+            // Arrange
+            var entryData = new Dictionary<string, object>
+            {
+                ["locale"] = "en-us",
+                ["uid"] = "uid",
+                ["blocks"] = new object[]
+                {
+                    new Dictionary<string, object>
+                    {
+                        ["hero"] = new Dictionary<string, object>
+                        {
+                            ["title"] = "Hero title",
+                            ["items"] = new object[] { null, new Dictionary<string, object> { ["name"] = "Item name" }, null }
+                        }
+                    },
+                    null,
+                    new Dictionary<string, object>
+                    {
+                        ["content"] = "Content text"
+                    }
+                }
+            };
+            var entry = CreateEditableEntry(entryData);
+
+            // Act & Assert - should not throw
+            Utils.addEditableTags(entry, "content_type", true);
+            
+            // Check that valid nested content got tagged
+            var blocks = (object[])entry.GetData()["blocks"];
+            var firstBlock = (Dictionary<string, object>)blocks[0];
+            var hero = (Dictionary<string, object>)firstBlock["hero"];
+            var heroTags = (Dictionary<string, object>)hero["$"];
+            var titleTag = (Dictionary<string, object>)heroTags["title"];
+            
+            Assert.Equal("content_type.uid.en-us.blocks.0.hero.title", titleTag["data-cslp"]);
+        }
+
+        #endregion
+    }
+
+}

--- a/Contentstack.Utils/Extensions/EditableEntryExtension.cs
+++ b/Contentstack.Utils/Extensions/EditableEntryExtension.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using Contentstack.Utils.Interfaces;
+
+namespace Contentstack.Utils.Extensions
+{
+    /// <summary>
+    /// Extension methods for EditableEntry to support Live Preview functionality.
+    /// </summary>
+    public static class EditableEntryExtension
+    {
+        /// <summary>
+        /// Checks if the EditableEntry contains a specific key.
+        /// </summary>
+        /// <param name="entry">The EditableEntry to check</param>
+        /// <param name="key">The key to check for</param>
+        /// <returns>True if the key exists and is accessible, false otherwise</returns>
+        public static bool ContainsKey(this EditableEntry entry, string key)
+        {
+            if (entry == null || string.IsNullOrEmpty(key))
+                return false;
+
+            try
+            {
+                // Try to access the key - if it doesn't exist, this will return null
+                // but won't throw for most implementations
+                var value = entry[key];
+                return true;
+            }
+            catch
+            {
+                // Key doesn't exist or access failed
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Safely gets a value from EditableEntry, returning null if key doesn't exist.
+        /// </summary>
+        /// <param name="entry">The EditableEntry to get from</param>
+        /// <param name="key">The key to get</param>
+        /// <returns>The value if key exists, null otherwise</returns>
+        public static object SafeGet(this EditableEntry entry, string key)
+        {
+            if (entry == null || string.IsNullOrEmpty(key))
+                return null;
+
+            try
+            {
+                return entry[key];
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Safely sets a value in EditableEntry, ignoring errors.
+        /// </summary>
+        /// <param name="entry">The EditableEntry to set in</param>
+        /// <param name="key">The key to set</param>
+        /// <param name="value">The value to set</param>
+        public static void SafeSet(this EditableEntry entry, string key, object value)
+        {
+            if (entry == null || string.IsNullOrEmpty(key))
+                return;
+
+            try
+            {
+                entry[key] = value;
+            }
+            catch
+            {
+                // Ignore set failures
+            }
+        }
+    }
+}

--- a/Contentstack.Utils/Models/LivePreviewOptions.cs
+++ b/Contentstack.Utils/Models/LivePreviewOptions.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+
+namespace Contentstack.Utils.Models
+{
+    /// <summary>
+    /// Options for addEditableTags method to control Live Preview tag generation behavior.
+    /// </summary>
+    public class AddEditableTagsOptions
+    {
+        /// <summary>
+        /// Whether to convert the locale to lowercase in generated tags. Defaults to true.
+        /// </summary>
+        public bool UseLowerCaseLocale { get; set; } = true;
+    }
+
+    /// <summary>
+    /// Container for applied variant information used during Live Preview tag generation.
+    /// </summary>
+    public class AppliedVariants
+    {
+        /// <summary>
+        /// Dictionary mapping field paths to variant identifiers.
+        /// </summary>
+        public Dictionary<string, string> _applied_variants { get; set; }
+
+        /// <summary>
+        /// Whether variant processing should be applied based on the presence of applied variants.
+        /// </summary>
+        public bool shouldApplyVariant { get; set; }
+
+        /// <summary>
+        /// The current field path being processed, used for variant inheritance lookups.
+        /// </summary>
+        public string metaKey { get; set; } = "";
+
+        public AppliedVariants()
+        {
+            _applied_variants = new Dictionary<string, string>();
+            shouldApplyVariant = false;
+        }
+
+        public AppliedVariants(Dictionary<string, string> appliedVariants, string metaKey = "")
+        {
+            _applied_variants = appliedVariants ?? new Dictionary<string, string>();
+            shouldApplyVariant = _applied_variants != null && _applied_variants.Count > 0;
+            this.metaKey = metaKey;
+        }
+    }
+}

--- a/Contentstack.Utils/Utils.cs
+++ b/Contentstack.Utils/Utils.cs
@@ -1,9 +1,10 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using Contentstack.Utils.Models;
 using HtmlAgilityPack;
 using Contentstack.Utils.Extensions;
 using Contentstack.Utils.Interfaces;
-using System;
 using Contentstack.Utils.Enums;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -200,69 +201,482 @@ namespace Contentstack.Utils
             return null;
         }
 
-        public static void addEditableTags(EditableEntry entry, string contentTypeUid, bool tagsAsObject, string locale = "en-us")
+        /// <summary>
+        /// Adds Live Preview editable tags to an entry for CMS editing capability.
+        /// This is the main public API method with enhanced options support.
+        /// </summary>
+        /// <param name="entry">The entry to add tags to</param>
+        /// <param name="contentTypeUid">Content type UID (will be lowercased)</param>
+        /// <param name="tagsAsObject">Whether to return tags as objects or strings</param>
+        /// <param name="locale">Locale for the entry (default: "en-us")</param>
+        /// <param name="options">Options controlling tag generation behavior</param>
+        public static void addEditableTags(EditableEntry entry, string contentTypeUid, bool tagsAsObject, string locale = "en-us", AddEditableTagsOptions options = null)
         {
-            if (entry != null)
-                entry["$"] = GetTag(entry, $"{contentTypeUid}.{entry.Uid}.{locale}", tagsAsObject, locale);
+            if (entry == null) return;
+
+            // Apply default options if not provided
+            options = options ?? new AddEditableTagsOptions();
+
+            // Normalize inputs according to JavaScript SDK behavior
+            contentTypeUid = contentTypeUid?.ToLowerInvariant() ?? "";
+            locale = options.UseLowerCaseLocale ? (locale?.ToLowerInvariant() ?? "en-us") : (locale ?? "en-us");
+
+            // Extract applied variants from entry
+            var appliedVariants = ExtractAppliedVariants(entry);
+
+            // Generate tags and assign to entry
+            entry["$"] = GetTag(entry, $"{contentTypeUid}.{entry.Uid}.{locale}", tagsAsObject, locale, appliedVariants);
         }
 
-        private static Dictionary<string, object> GetTag(object content, string prefix, bool tagsAsObject, string locale)
+
+        /// <summary>
+        /// Alias for addEditableTags to match JavaScript SDK naming.
+        /// </summary>
+        public static void addTags(EditableEntry entry, string contentTypeUid, bool tagsAsObject, string locale = "en-us", AddEditableTagsOptions options = null)
         {
+            addEditableTags(entry, contentTypeUid, tagsAsObject, locale, options);
+        }
+
+        /// <summary>
+        /// Enhanced GetTag method with comprehensive variant support and proper null handling.
+        /// </summary>
+        private static Dictionary<string, object> GetTag(object content, string prefix, bool tagsAsObject, string locale, AppliedVariants appliedVariants)
+        {
+            // Null safety - return empty tags if content is null or undefined
+            if (content == null) return new Dictionary<string, object>();
+
             var tags = new Dictionary<string, object>();
-            foreach (var property in (Dictionary<string, object>)content)
+            
+            // Handle Dictionary<string, object> directly
+            if (content is Dictionary<string, object> contentDict)
             {
-                var key = property.Key;
-                var value = property.Value;
-
-                if (key == "$")
-                    continue;
-                    
-                switch (value)
+                foreach (var property in contentDict)
                 {
-                    case object obj when obj is object[] array:
-                        for (int index = 0; index < array.Length; index++)
-                        {
-                            object objValue = array[index]; 
-                            string childKey = $"{key}__{index}";
-                            string parentKey = $"{key}__parent";
-
-                            tags[childKey] = GetTagsValue($"{prefix}.{key}.{index}", tagsAsObject);
-                            tags[parentKey] = GetParentTagsValue($"{prefix}.{key}", tagsAsObject);
-
-                            if (objValue != null &&
-                                objValue.GetType().GetProperty("_content_type_uid") != null &&
-                                objValue.GetType().GetProperty("Uid") != null)
-                            {
-                                var typedObj = (EditableEntry)objValue;
-                                string locale_ = Convert.ToString(typedObj.GetType().GetProperty("locale").GetValue(typedObj));
-                                string ctUid = Convert.ToString(typedObj.GetType().GetProperty("_content_type_uid").GetValue(typedObj));
-                                string uid = Convert.ToString(typedObj.GetType().GetProperty("uid").GetValue(typedObj));
-                                string localeStr = "";
-                                if (locale_ != null)
-                                {
-                                    localeStr = locale_;
-                                } else
-                                {
-                                    localeStr = locale;
-                                }
-                                typedObj["$"] = GetTag(typedObj, $"{ctUid}.{uid}.{localeStr}", tagsAsObject, locale);
-                            }
-                            else if (value is object)
-                            {
-                                ((EditableEntry)value)["$"] = GetTag(value, $"{prefix}.{key}.{index}", tagsAsObject, locale);
-                            }
-                        }
-                        tags[key] = GetTagsValue($"{prefix}.{key}", tagsAsObject);
-                        break;
-                    case object obj when obj != null:
-                        if (value != null)
-                        {
-                            ((EditableEntry)value)["$"] = GetTag(value, $"{prefix}.{key}", tagsAsObject, locale);
-                        }
-                        break;
+                    ProcessContentProperty(property.Key, property.Value, prefix, tagsAsObject, locale, appliedVariants, tags);
                 }
             }
+            // Handle EditableEntry interface
+            else if (content is EditableEntry editableEntry)
+            {
+                // For EditableEntry, we need to get the underlying data
+                // Use reflection or casting to get the data
+                try
+                {
+                    // Try to get the underlying dictionary if it's our mock class
+                    var getDataMethod = content.GetType().GetMethod("GetData");
+                    if (getDataMethod != null)
+                    {
+                        var data = (Dictionary<string, object>)getDataMethod.Invoke(content, null);
+                        foreach (var property in data)
+                        {
+                            ProcessContentProperty(property.Key, property.Value, prefix, tagsAsObject, locale, appliedVariants, tags);
+                        }
+                    }
+                    else
+                    {
+                        // Fallback: try to cast to dictionary
+                        var dict = (Dictionary<string, object>)content;
+                        foreach (var property in dict)
+                        {
+                            ProcessContentProperty(property.Key, property.Value, prefix, tagsAsObject, locale, appliedVariants, tags);
+                        }
+                    }
+                }
+                catch
+                {
+                    // If all else fails, return empty tags
+                    return tags;
+                }
+            }
+
             return tags;
+        }
+
+        /// <summary>
+        /// Processes a single content property for tag generation.
+        /// </summary>
+        private static void ProcessContentProperty(string key, object value, string prefix, bool tagsAsObject, 
+            string locale, AppliedVariants appliedVariants, Dictionary<string, object> tags)
+        {
+            // Skip the $ key to avoid recursive processing
+            if (key == "$") return;
+
+            // Extract metadata UID for variant path building
+            string metaUID = ExtractMetadataUid(value);
+            
+            // Build updated meta key for variant processing
+            string updatedMetakey = BuildUpdatedMetaKey(appliedVariants, key, metaUID);
+
+            // Process based on value type
+            if (IsArrayType(value))
+            {
+                ProcessArrayField(value, key, prefix, tagsAsObject, locale, appliedVariants, updatedMetakey, tags);
+            }
+            else if (value != null)
+            {
+                ProcessObjectField(value, key, prefix, tagsAsObject, locale, appliedVariants, updatedMetakey, tags);
+            }
+
+            // Always emit a tag for the field itself (even if value is null)
+            var fieldPath = $"{prefix}.{key}";
+            var fieldVariants = new AppliedVariants(appliedVariants._applied_variants, updatedMetakey);
+            tags[key] = GetTagsValue(ApplyVariantToDataValue(fieldPath, fieldVariants), tagsAsObject);
+        }
+
+        /// <summary>
+        /// Legacy GetTag overload for backward compatibility.
+        /// </summary>
+        private static Dictionary<string, object> GetTag(object content, string prefix, bool tagsAsObject, string locale)
+        {
+            var emptyVariants = new AppliedVariants();
+            return GetTag(content, prefix, tagsAsObject, locale, emptyVariants);
+        }
+
+        /// <summary>
+        /// Extracts applied variants from an entry, checking both _applied_variants and system.applied_variants.
+        /// </summary>
+        private static AppliedVariants ExtractAppliedVariants(EditableEntry entry)
+        {
+            Dictionary<string, string> variants = null;
+
+            // Try to get _applied_variants first (direct property)
+            if (entry.ContainsKey("_applied_variants") && entry["_applied_variants"] != null)
+            {
+                variants = ConvertToStringDictionary(entry["_applied_variants"]);
+            }
+            // Fallback to system.applied_variants
+            else if (entry.ContainsKey("system") && entry["system"] != null)
+            {
+                try
+                {
+                    var system = (Dictionary<string, object>)entry["system"];
+                    if (system.ContainsKey("applied_variants") && system["applied_variants"] != null)
+                    {
+                        variants = ConvertToStringDictionary(system["applied_variants"]);
+                    }
+                }
+                catch { /* Ignore conversion errors */ }
+            }
+
+            return new AppliedVariants(variants);
+        }
+
+        /// <summary>
+        /// Safely converts an object to a string dictionary for variant processing.
+        /// </summary>
+        private static Dictionary<string, string> ConvertToStringDictionary(object obj)
+        {
+            try
+            {
+                if (obj is Dictionary<string, object> dict)
+                {
+                    var result = new Dictionary<string, string>();
+                    foreach (var kvp in dict)
+                    {
+                        if (kvp.Value != null)
+                        {
+                            result[kvp.Key] = kvp.Value.ToString();
+                        }
+                    }
+                    return result;
+                }
+                else if (obj is Dictionary<string, string> strDict)
+                {
+                    return new Dictionary<string, string>(strDict);
+                }
+            }
+            catch { /* Ignore conversion errors */ }
+
+            return new Dictionary<string, string>();
+        }
+
+        /// <summary>
+        /// Checks if a value is an array type that needs array processing.
+        /// </summary>
+        private static bool IsArrayType(object value)
+        {
+            return value is object[] || 
+                   value is List<object> || 
+                   value is IEnumerable<object>;
+        }
+
+        /// <summary>
+        /// Extracts metadata UID from a value object for variant path building.
+        /// </summary>
+        private static string ExtractMetadataUid(object value)
+        {
+            try
+            {
+                if (value is Dictionary<string, object> dict &&
+                    dict.ContainsKey("_metadata") && 
+                    dict["_metadata"] is Dictionary<string, object> metadata &&
+                    metadata.ContainsKey("uid"))
+                {
+                    return metadata["uid"]?.ToString();
+                }
+            }
+            catch { /* Ignore extraction errors */ }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Builds the updated meta key for variant processing, including metadata UID when applicable.
+        /// </summary>
+        private static string BuildUpdatedMetaKey(AppliedVariants appliedVariants, string key, string metaUID)
+        {
+            var metaKeyPrefix = string.IsNullOrEmpty(appliedVariants.metaKey) ? "" : appliedVariants.metaKey + ".";
+            var baseMetaKey = metaKeyPrefix + key;
+            
+            // Append metadata UID if variants are applied and metaUID exists
+            if (appliedVariants.shouldApplyVariant && !string.IsNullOrEmpty(metaUID) && !string.IsNullOrEmpty(baseMetaKey))
+            {
+                return baseMetaKey + "." + metaUID;
+            }
+            
+            return baseMetaKey;
+        }
+
+        /// <summary>
+        /// Processes array fields with proper null handling, reference detection, and variant support.
+        /// </summary>
+        private static void ProcessArrayField(object value, string key, string prefix, bool tagsAsObject, 
+            string locale, AppliedVariants appliedVariants, string updatedMetakey, Dictionary<string, object> tags)
+        {
+            // Convert to object array for processing
+            object[] array;
+            try
+            {
+                if (value is object[] objArray)
+                    array = objArray;
+                else if (value is List<object> list)
+                    array = list.ToArray();
+                else
+                    return; // Cannot process this array type
+            }
+            catch
+            {
+                return; // Conversion failed
+            }
+
+            // Process each array element
+            for (int index = 0; index < array.Length; index++)
+            {
+                object objValue = array[index];
+                
+                // Skip null and undefined elements (matching JavaScript SDK behavior)
+                if (objValue == null) continue;
+
+                string childKey = $"{key}__{index}";
+                string parentKey = $"{key}__parent";
+
+                // Generate field__index and field__parent tags
+                var indexPath = $"{prefix}.{key}.{index}";
+                var parentPath = $"{prefix}.{key}";
+                
+                var indexVariants = new AppliedVariants(appliedVariants._applied_variants, updatedMetakey);
+                var parentVariants = new AppliedVariants(appliedVariants._applied_variants, appliedVariants.metaKey + (string.IsNullOrEmpty(appliedVariants.metaKey) ? "" : ".") + key);
+
+                tags[childKey] = GetTagsValue(ApplyVariantToDataValue(indexPath, indexVariants), tagsAsObject);
+                tags[parentKey] = GetParentTagsValue(ApplyVariantToDataValue(parentPath, parentVariants), tagsAsObject);
+
+                // Handle reference entries vs regular objects
+                if (IsReferenceEntry(objValue))
+                {
+                    ProcessReferenceEntry(objValue, tagsAsObject, locale);
+                }
+                else if (objValue is Dictionary<string, object>)
+                {
+                    var elementVariants = new AppliedVariants(appliedVariants._applied_variants, updatedMetakey);
+                    ((Dictionary<string, object>)objValue)["$"] = GetTag(objValue, indexPath, tagsAsObject, locale, elementVariants);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Processes object fields with variant support.
+        /// </summary>
+        private static void ProcessObjectField(object value, string key, string prefix, bool tagsAsObject,
+            string locale, AppliedVariants appliedVariants, string updatedMetakey, Dictionary<string, object> tags)
+        {
+            try
+            {
+                if (value is Dictionary<string, object> dict)
+                {
+                    var fieldVariants = new AppliedVariants(appliedVariants._applied_variants, updatedMetakey);
+                    dict["$"] = GetTag(value, $"{prefix}.{key}", tagsAsObject, locale, fieldVariants);
+                }
+            }
+            catch { /* Ignore processing errors for malformed objects */ }
+        }
+
+        /// <summary>
+        /// Checks if an object is a reference entry (has both _content_type_uid and uid properties).
+        /// </summary>
+        private static bool IsReferenceEntry(object obj)
+        {
+            try
+            {
+                if (obj is Dictionary<string, object> dict)
+                {
+                    return dict.ContainsKey("_content_type_uid") && 
+                           dict.ContainsKey("uid") &&
+                           dict["_content_type_uid"] != null && 
+                           dict["uid"] != null;
+                }
+            }
+            catch { }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Processes reference entries with independent variant handling.
+        /// </summary>
+        private static void ProcessReferenceEntry(object referenceObj, bool tagsAsObject, string parentLocale)
+        {
+            try
+            {
+                var refDict = (Dictionary<string, object>)referenceObj;
+                
+                // Extract reference properties
+                string refContentTypeUid = refDict["_content_type_uid"]?.ToString();
+                string refUid = refDict["uid"]?.ToString();
+                string refLocale = refDict.ContainsKey("locale") ? refDict["locale"]?.ToString() : null;
+                
+                if (string.IsNullOrEmpty(refContentTypeUid) || string.IsNullOrEmpty(refUid))
+                    return;
+
+                // Use reference locale or fallback to parent locale
+                string effectiveLocale = !string.IsNullOrEmpty(refLocale) ? refLocale : parentLocale;
+                
+                // Extract reference-specific variants (do not inherit parent variants)
+                var refVariants = ExtractAppliedVariantsFromObject(refDict);
+                
+                // Generate tags for reference using its own content type, UID, and locale
+                string refPrefix = $"{refContentTypeUid.ToLowerInvariant()}.{refUid}.{effectiveLocale.ToLowerInvariant()}";
+                refDict["$"] = GetTag(referenceObj, refPrefix, tagsAsObject, effectiveLocale, refVariants);
+            }
+            catch { /* Ignore processing errors for malformed references */ }
+        }
+
+        /// <summary>
+        /// Extracts applied variants from a generic object (used for reference entries).
+        /// </summary>
+        private static AppliedVariants ExtractAppliedVariantsFromObject(Dictionary<string, object> obj)
+        {
+            Dictionary<string, string> variants = null;
+
+            // Try _applied_variants first
+            if (obj.ContainsKey("_applied_variants") && obj["_applied_variants"] != null)
+            {
+                variants = ConvertToStringDictionary(obj["_applied_variants"]);
+            }
+            // Fallback to system.applied_variants
+            else if (obj.ContainsKey("system") && obj["system"] is Dictionary<string, object> system)
+            {
+                if (system.ContainsKey("applied_variants") && system["applied_variants"] != null)
+                {
+                    variants = ConvertToStringDictionary(system["applied_variants"]);
+                }
+            }
+
+            return new AppliedVariants(variants);
+        }
+
+        /// <summary>
+        /// Applies variant processing to a data value, adding v2: prefix and variant suffix when applicable.
+        /// </summary>
+        private static string ApplyVariantToDataValue(string dataValue, AppliedVariants appliedVariants)
+        {
+            if (!appliedVariants.shouldApplyVariant || appliedVariants._applied_variants == null)
+            {
+                return dataValue;
+            }
+
+            string variant = null;
+
+            // Check for direct field match
+            if (appliedVariants._applied_variants.ContainsKey(appliedVariants.metaKey))
+            {
+                variant = appliedVariants._applied_variants[appliedVariants.metaKey];
+            }
+            else
+            {
+                // Find parent variantised path
+                string parentPath = GetParentVariantisedPath(appliedVariants);
+                if (!string.IsNullOrEmpty(parentPath))
+                {
+                    variant = appliedVariants._applied_variants[parentPath];
+                }
+            }
+
+            if (string.IsNullOrEmpty(variant))
+            {
+                return dataValue;
+            }
+
+            // Apply v2: prefix and variant suffix to UID segment
+            try
+            {
+                var segments = ("v2:" + dataValue).Split('.');
+                if (segments.Length >= 2)
+                {
+                    // Modify the UID segment (index 1 after v2: prefix)
+                    segments[1] = segments[1] + "_" + variant;
+                    return string.Join(".", segments);
+                }
+            }
+            catch { }
+
+            return dataValue;
+        }
+
+        /// <summary>
+        /// Finds the longest matching parent path for variant inheritance.
+        /// </summary>
+        private static string GetParentVariantisedPath(AppliedVariants appliedVariants)
+        {
+            try
+            {
+                if (appliedVariants._applied_variants == null || string.IsNullOrEmpty(appliedVariants.metaKey))
+                {
+                    return "";
+                }
+
+                var childPathFragments = appliedVariants.metaKey.Split('.');
+                
+                // Sort keys by length descending for longest match preference
+                var sortedKeys = new List<string>(appliedVariants._applied_variants.Keys);
+                sortedKeys.Sort((a, b) => b.Length.CompareTo(a.Length));
+
+                foreach (var path in sortedKeys)
+                {
+                    var parentFragments = path.Split('.');
+                    
+                    // Check if this path is a parent of the current meta key
+                    if (parentFragments.Length <= childPathFragments.Length)
+                    {
+                        bool isParent = true;
+                        for (int i = 0; i < parentFragments.Length; i++)
+                        {
+                            if (parentFragments[i] != childPathFragments[i])
+                            {
+                                isParent = false;
+                                break;
+                            }
+                        }
+                        
+                        if (isParent)
+                        {
+                            return path;
+                        }
+                    }
+                }
+            }
+            catch { }
+
+            return "";
         }
 
         private static object GetTagsValue(string dataValue, bool tagsAsObject)


### PR DESCRIPTION
## Live Preview Implementation

Implements comprehensive Live Preview functionality to achieve parity with the JavaScript SDK's `entry-editable.ts`, enabling CMS editors to edit content directly through `data-cslp` attributes.

### Key Features

- `addEditableTags()` and `addTags()` methods with full API compatibility  
- Variant support with `v2:` prefix and `_{variantId}` suffix processing  
- Advanced array handling with proper indexing and null safety  
- Reference entry processing with separate content type contexts  
- Case-insensitive `contentTypeUid` / `locale` handling with configurable options  