### PR TITLE
feat: add multi-region endpoint resolution with self-heal regions registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ packages/
 */TestResults/
 */app.config
 .dccache
+*/Assets/regions.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 - JSON serialization uses the same model attributes with `System.Text.Json.Serialization` (`JsonPropertyName`, `JsonConverter`), including custom converters for RTE/GQL-shaped JSON and **path-mapped** embedded models (`PathMappedJsonConverter<T>`).
 - RTE JSON deserialization tolerates **trailing commas** when using the documented test/helper patterns (`AllowTrailingCommas`); attribute dictionaries may surface **`JsonElement`** values instead of boxed strings—use helpers or unwrap explicitly if you access `Node.attrs` directly.
 - Internal: `LangVersion` set to **latest** for multi-target builds; utilities normalize attribute values where the HTML pipeline expects strings.
+- **New:** Multi-region endpoint resolution via `Endpoint.GetContentstackEndpoint(region, service)` — resolves Contentstack service URLs for all 7 supported regions (NA, EU, AU, Azure-NA, Azure-EU, GCP-NA, GCP-EU) and 18 service keys (contentDelivery, contentManagement, auth, graphqlDelivery, preview, images, assets, automate, launch, developerHub, brandKit, genAI, personalizeManagement, personalizeEdge, composableStudio, assetManagement, and more).
+- **New:** `Utils.GetContentstackEndpoint(region, service)` proxy — access endpoint resolution directly from the `Utils` class without importing `Contentstack.Utils.Endpoints`.
+- **New:** `omitHttps` flag strips the `https://` scheme from returned URLs — pass directly to SDK host configuration (e.g. `new ContentstackOptions { Host = Endpoint.GetContentstackEndpoint("eu", "contentDelivery", omitHttps: true) }`).
+- **New:** Case-insensitive region alias support — `"us"`, `"NA"`, `"AWS-NA"`, `"azure_na"` all resolve correctly to the same region.
+- **New:** `regions.json` registry auto-downloaded from `artifacts.contentstack.com` on first use and cached on disk — no setup required. The SDK self-heals if the file is missing.
+- **New:** `Scripts/refresh-region.cs` bundled inside the NuGet package — automatically placed in your project's `Scripts/` folder on first `dotnet build`. Run `dotnet run Scripts/refresh-region.cs` anytime to pull the latest regions from CDN.
 
 ### Version: 2.0.0-beta.1
 #### Date: April-27-2026

--- a/Contentstack.Utils.Tests/EndpointTest.cs
+++ b/Contentstack.Utils.Tests/EndpointTest.cs
@@ -228,7 +228,7 @@ namespace Contentstack.Utils.Tests
         }
 
         // ------------------------------------------------------------------
-        // Local file self-heal (mirrors Python _download_and_save behaviour)
+        // Local file self-heal.
         // ------------------------------------------------------------------
 
         [Fact]

--- a/Contentstack.Utils.Tests/EndpointTest.cs
+++ b/Contentstack.Utils.Tests/EndpointTest.cs
@@ -1,0 +1,263 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Contentstack.Utils.Endpoints;
+using Xunit;
+
+namespace Contentstack.Utils.Tests
+{
+    public class EndpointTest : IDisposable
+    {
+        // Reset cache before each test so tests are isolated.
+        public EndpointTest()
+        {
+            Endpoint.ResetCache();
+        }
+
+        public void Dispose()
+        {
+            Endpoint.ResetCache();
+        }
+
+        // ------------------------------------------------------------------
+        // Basic resolution
+        // ------------------------------------------------------------------
+
+        [Fact]
+        public void GetContentstackEndpoint_Na_ReturnsCorrectCdnUrl()
+        {
+            string url = Endpoint.GetContentstackEndpoint("na", "contentDelivery");
+            Assert.Equal("https://cdn.contentstack.io", url);
+        }
+
+        [Theory]
+        [InlineData("na")]
+        [InlineData("eu")]
+        [InlineData("au")]
+        [InlineData("azure-na")]
+        [InlineData("azure-eu")]
+        [InlineData("gcp-na")]
+        [InlineData("gcp-eu")]
+        public void GetContentstackEndpoint_AllRegionIds_Resolve(string regionId)
+        {
+            string url = Endpoint.GetContentstackEndpoint(regionId, "contentDelivery");
+            Assert.False(string.IsNullOrEmpty(url));
+            Assert.StartsWith("https://", url);
+        }
+
+        // ------------------------------------------------------------------
+        // Alias resolution (case-insensitive, dash/underscore variants)
+        // ------------------------------------------------------------------
+
+        [Theory]
+        [InlineData("na")]
+        [InlineData("us")]
+        [InlineData("NA")]
+        [InlineData("US")]
+        [InlineData("AWS-NA")]
+        [InlineData("aws_na")]
+        [InlineData("AWS_NA")]
+        public void GetContentstackEndpoint_NaAliasVariants_AllResolveToSameCdn(string alias)
+        {
+            string url = Endpoint.GetContentstackEndpoint(alias, "contentDelivery");
+            Assert.Equal("https://cdn.contentstack.io", url);
+        }
+
+        [Theory]
+        [InlineData("azure-na")]
+        [InlineData("azure_na")]
+        [InlineData("AZURE-NA")]
+        [InlineData("AZURE_NA")]
+        public void GetContentstackEndpoint_AzureNaAliasVariants_AllResolveToSameUrl(string alias)
+        {
+            string expected = Endpoint.GetContentstackEndpoint("azure-na", "contentDelivery");
+            string result = Endpoint.GetContentstackEndpoint(alias, "contentDelivery");
+            Assert.Equal(expected, result);
+        }
+
+        // ------------------------------------------------------------------
+        // omitHttps flag
+        // ------------------------------------------------------------------
+
+        [Fact]
+        public void GetContentstackEndpoint_OmitHttps_StripsScheme()
+        {
+            string host = Endpoint.GetContentstackEndpoint("na", "contentDelivery", omitHttps: true);
+            Assert.Equal("cdn.contentstack.io", host);
+        }
+
+        [Fact]
+        public void GetContentstackEndpoint_OmitHttps_EuRegion_StripsScheme()
+        {
+            string host = Endpoint.GetContentstackEndpoint("eu", "contentDelivery", omitHttps: true);
+            Assert.Equal("eu-cdn.contentstack.com", host);
+        }
+
+        [Fact]
+        public void GetContentstackEndpoint_OmitHttpsFalse_ReturnsFullUrl()
+        {
+            string url = Endpoint.GetContentstackEndpoint("na", "contentDelivery", omitHttps: false);
+            Assert.StartsWith("https://", url);
+        }
+
+        // ------------------------------------------------------------------
+        // All-endpoints (dict) overload
+        // ------------------------------------------------------------------
+
+        [Theory]
+        [InlineData("na")]
+        [InlineData("eu")]
+        [InlineData("au")]
+        [InlineData("azure-na")]
+        [InlineData("azure-eu")]
+        [InlineData("gcp-na")]
+        [InlineData("gcp-eu")]
+        public void GetContentstackEndpoint_AllEndpoints_ContainsExpectedKeys(string regionId)
+        {
+            var endpoints = Endpoint.GetContentstackEndpoint(regionId);
+            Assert.True(endpoints.Count > 0);
+            Assert.True(endpoints.ContainsKey("contentDelivery"));
+            Assert.True(endpoints.ContainsKey("contentManagement"));
+            Assert.True(endpoints.ContainsKey("auth"));
+        }
+
+        [Fact]
+        public void GetContentstackEndpoint_NaAllEndpoints_Has18Keys()
+        {
+            var endpoints = Endpoint.GetContentstackEndpoint("na");
+            Assert.Equal(18, endpoints.Count);
+        }
+
+        [Fact]
+        public void GetContentstackEndpoint_AllEndpoints_OmitHttps_AllValuesStripped()
+        {
+            var endpoints = Endpoint.GetContentstackEndpoint("na", omitHttps: true);
+            foreach (var url in endpoints.Values)
+                Assert.DoesNotContain("https://", url);
+        }
+
+        // ------------------------------------------------------------------
+        // Error handling
+        // ------------------------------------------------------------------
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void GetContentstackEndpoint_EmptyRegion_ThrowsArgumentException(string emptyRegion)
+        {
+            Assert.Throws<ArgumentException>(() =>
+                Endpoint.GetContentstackEndpoint(emptyRegion, "contentDelivery"));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void GetContentstackEndpoint_EmptyRegion_DictOverload_ThrowsArgumentException(string emptyRegion)
+        {
+            Assert.Throws<ArgumentException>(() =>
+                Endpoint.GetContentstackEndpoint(emptyRegion));
+        }
+
+        [Fact]
+        public void GetContentstackEndpoint_UnknownRegion_ThrowsKeyNotFoundException()
+        {
+            Assert.Throws<KeyNotFoundException>(() =>
+                Endpoint.GetContentstackEndpoint("xyz", "contentDelivery"));
+        }
+
+        [Fact]
+        public void GetContentstackEndpoint_UnknownService_ThrowsKeyNotFoundException()
+        {
+            var ex = Assert.Throws<KeyNotFoundException>(() =>
+                Endpoint.GetContentstackEndpoint("na", "nonExistentService"));
+            Assert.Contains("nonExistentService", ex.Message);
+        }
+
+        // ------------------------------------------------------------------
+        // Cache behaviour
+        // ------------------------------------------------------------------
+
+        [Fact]
+        public void ResetCache_AllowsReload_NoError()
+        {
+            // First call populates cache
+            Endpoint.GetContentstackEndpoint("na", "contentDelivery");
+
+            // Reset and call again — should reload without error
+            Endpoint.ResetCache();
+            string url = Endpoint.GetContentstackEndpoint("na", "contentDelivery");
+            Assert.Equal("https://cdn.contentstack.io", url);
+        }
+
+        [Fact]
+        public void GetContentstackEndpoint_ConsecutiveCalls_ReturnConsistentResults()
+        {
+            string first = Endpoint.GetContentstackEndpoint("eu", "contentManagement");
+            string second = Endpoint.GetContentstackEndpoint("eu", "contentManagement");
+            Assert.Equal(first, second);
+        }
+
+        // ------------------------------------------------------------------
+        // Utils proxy parity
+        // ------------------------------------------------------------------
+
+        [Fact]
+        public void Utils_Proxy_String_MatchesEndpoint()
+        {
+            string direct = Endpoint.GetContentstackEndpoint("na", "contentDelivery");
+            string proxy = Utils.GetContentstackEndpoint("na", "contentDelivery");
+            Assert.Equal(direct, proxy);
+        }
+
+        [Fact]
+        public void Utils_Proxy_Dict_MatchesEndpoint()
+        {
+            var direct = Endpoint.GetContentstackEndpoint("eu");
+            var proxy = Utils.GetContentstackEndpoint("eu");
+            Assert.Equal(direct.Count, proxy.Count);
+            foreach (var kvp in direct)
+                Assert.Equal(kvp.Value, proxy[kvp.Key]);
+        }
+
+        [Fact]
+        public void Utils_Proxy_OmitHttps_MatchesEndpoint()
+        {
+            string direct = Endpoint.GetContentstackEndpoint("eu", "contentDelivery", omitHttps: true);
+            string proxy = Utils.GetContentstackEndpoint("eu", "contentDelivery", omitHttps: true);
+            Assert.Equal(direct, proxy);
+        }
+
+        // ------------------------------------------------------------------
+        // Local file self-heal (mirrors Python _download_and_save behaviour)
+        // ------------------------------------------------------------------
+
+        [Fact]
+        public void LocalFile_WhenWritten_IsReadOnNextCacheReset()
+        {
+            // First call: either reads from disk or downloads from CDN and writes to disk.
+            Endpoint.GetContentstackEndpoint("na", "contentDelivery");
+
+            string localPath = Endpoint.GetLocalFilePath();
+
+            // If CDN download failed (no network in CI), skip this assertion — the
+            // self-heal path is covered by the CDN download succeeding at call time.
+            if (!File.Exists(localPath))
+                return;
+
+            // Reset cache — next call must read from local file (step 2 in LoadRegions),
+            // not re-download. Mirrors Python: os.path.exists(_REGIONS_FILE) → open().
+            Endpoint.ResetCache();
+            string url = Endpoint.GetContentstackEndpoint("na", "contentDelivery");
+
+            Assert.Equal("https://cdn.contentstack.io", url);
+        }
+
+        [Fact]
+        public void LocalFilePath_IsNextToDll_NotSourceDirectory()
+        {
+            string localPath = Endpoint.GetLocalFilePath();
+            Assert.Contains("Assets", localPath);
+            Assert.EndsWith("regions.json", localPath);
+        }
+    }
+}

--- a/Contentstack.Utils/Contentstack.Utils.csproj
+++ b/Contentstack.Utils/Contentstack.Utils.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net47;net472;</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <PackageId>contentstack.utils</PackageId>
     <RootNamespace>Contentstack.Utils</RootNamespace>
@@ -38,9 +38,27 @@
     <Folder Include="Extensions\" />
     <Folder Include="Converters\" />
     <Folder Include="Constants\" />
+    <Folder Include="Endpoints\" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
+
+  <!-- Ship refresh-region.cs inside the NuGet package.
+       The .targets file copies it into the consumer's Scripts/ folder on first build.
+       Customer runs:  dotnet run Scripts/refresh-region.cs                -->
+  <ItemGroup>
+    <Content Include="..\Scripts\refresh-region.cs">
+      <Pack>true</Pack>
+      <PackagePath>contentFiles/cs/any/Scripts/refresh-region.cs</PackagePath>
+      <BuildAction>Content</BuildAction>
+      <CopyToOutput>false</CopyToOutput>
+    </Content>
+    <None Include="..\build\contentstack.utils.targets">
+      <Pack>true</Pack>
+      <PackagePath>build/contentstack.utils.targets</PackagePath>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/Contentstack.Utils/Endpoints/Endpoint.cs
+++ b/Contentstack.Utils/Endpoints/Endpoint.cs
@@ -1,0 +1,287 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace Contentstack.Utils.Endpoints
+{
+    /// <summary>
+    /// Resolves Contentstack service URLs for any supported region.
+    ///
+    /// All public methods are static — no instantiation required.
+    ///
+    /// Example:
+    /// <code>
+    /// // Full URL
+    /// string url = Endpoint.GetContentstackEndpoint("na", "contentDelivery");
+    /// // → "https://cdn.contentstack.io"
+    ///
+    /// // Host only (omit https://) — useful for SDK host configuration
+    /// string host = Endpoint.GetContentstackEndpoint("eu", "contentDelivery", omitHttps: true);
+    /// // → "eu-cdn.contentstack.com"
+    ///
+    /// // All endpoints for a region
+    /// Dictionary&lt;string, string&gt; all = Endpoint.GetContentstackEndpoint("azure-na");
+    /// // → { "contentDelivery": "...", "contentManagement": "...", ... }
+    /// </code>
+    /// </summary>
+    public static class Endpoint
+    {
+        private const string RegionsUrl = "https://artifacts.contentstack.com/regions.json";
+
+        // Module-level cache — loaded once per process, shared across all calls.
+        private static JsonElement[]? _regionsData;
+        private static readonly object _cacheLock = new object();
+        private static readonly HttpClient _httpClient = new HttpClient
+        {
+            Timeout = TimeSpan.FromSeconds(30)
+        };
+
+        /// <summary>
+        /// Resolves a single Contentstack service endpoint URL for the given region.
+        /// </summary>
+        /// <param name="region">
+        /// Region ID or alias (case-insensitive). Examples: "na", "us", "eu", "AWS-NA", "azure_eu", "gcp-na".
+        /// </param>
+        /// <param name="service">
+        /// Service key. Valid keys include: "contentDelivery", "contentManagement", "auth",
+        /// "graphqlDelivery", "preview", "images", "assets", "automate", "launch",
+        /// "developerHub", "brandKit", "genAI", "personalizeManagement",
+        /// "personalizeEdge", "composableStudio", "assetManagement".
+        /// </param>
+        /// <param name="omitHttps">
+        /// When true, strips the https:// scheme from the returned URL.
+        /// Useful when passing the host to an SDK that constructs its own URLs.
+        /// </param>
+        /// <returns>The endpoint URL string for the specified service.</returns>
+        /// <exception cref="ArgumentException">If region is empty or whitespace.</exception>
+        /// <exception cref="KeyNotFoundException">If region or service is not found.</exception>
+        /// <exception cref="InvalidOperationException">If the registry cannot be read or is corrupt.</exception>
+        public static string GetContentstackEndpoint(string region, string service, bool omitHttps = false)
+        {
+            if (string.IsNullOrWhiteSpace(region))
+                throw new ArgumentException("Empty region provided. Please put valid region.", nameof(region));
+
+            var regions = LoadRegions();
+            string normalized = region.Trim().ToLowerInvariant();
+            var regionEl = FindRegion(regions, normalized);
+
+            if (regionEl == null)
+                throw new KeyNotFoundException($"Invalid region: {region}");
+
+            var endpoints = regionEl.Value.GetProperty("endpoints");
+            if (!endpoints.TryGetProperty(service, out var urlEl))
+            {
+                string regionId = regionEl.Value.GetProperty("id").GetString()!;
+                throw new KeyNotFoundException($"Service \"{service}\" not found for region \"{regionId}\"");
+            }
+
+            string url = urlEl.GetString()!;
+            return omitHttps ? StripHttps(url) : url;
+        }
+
+        /// <summary>
+        /// Returns all service endpoint URLs for the given region.
+        /// </summary>
+        /// <param name="region">Region ID or alias (case-insensitive).</param>
+        /// <param name="omitHttps">When true, strips the https:// scheme from all returned URLs.</param>
+        /// <returns>Dictionary mapping service keys to endpoint URLs.</returns>
+        /// <exception cref="ArgumentException">If region is empty or whitespace.</exception>
+        /// <exception cref="KeyNotFoundException">If region is not found.</exception>
+        /// <exception cref="InvalidOperationException">If the registry cannot be read or is corrupt.</exception>
+        public static Dictionary<string, string> GetContentstackEndpoint(string region, bool omitHttps = false)
+        {
+            if (string.IsNullOrWhiteSpace(region))
+                throw new ArgumentException("Empty region provided. Please put valid region.", nameof(region));
+
+            var regions = LoadRegions();
+            string normalized = region.Trim().ToLowerInvariant();
+            var regionEl = FindRegion(regions, normalized);
+
+            if (regionEl == null)
+                throw new KeyNotFoundException($"Invalid region: {region}");
+
+            var result = new Dictionary<string, string>();
+            var endpoints = regionEl.Value.GetProperty("endpoints");
+            foreach (var ep in endpoints.EnumerateObject())
+            {
+                string url = ep.Value.GetString()!;
+                result[ep.Name] = omitHttps ? StripHttps(url) : url;
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Clears the in-memory region cache. Intended for testing only — forces the
+        /// next call to re-read regions.json from disk or re-download from CDN.
+        /// </summary>
+        public static void ResetCache()
+        {
+            lock (_cacheLock)
+            {
+                _regionsData = null;
+            }
+        }
+
+        // ------------------------------------------------------------------
+        // Internal helpers
+        // ------------------------------------------------------------------
+
+        /// <summary>
+        /// Load and cache the regions registry.
+        ///
+        /// Resolution order:
+        ///   1. In-memory cache    — zero I/O after the first call in a process
+        ///   2. Local file on disk — Assets/regions.json next to the DLL
+        ///                          (written by DownloadAndSave or refresh-region.cs)
+        ///   3. CDN download       — fetches from artifacts.contentstack.com,
+        ///                          writes to disk for future calls (silent on failure)
+        /// </summary>
+        private static JsonElement[] LoadRegions()
+        {
+            lock (_cacheLock)
+            {
+                if (_regionsData != null)
+                    return _regionsData;
+
+                string localFile = GetLocalFilePath();
+
+                // Step 2 — local file on disk 
+                string? json = ReadLocalFile(localFile);
+
+                // Step 3 — CDN download, writes to disk so next startup skips this step         
+                if (json == null)
+                    json = DownloadAndSave(localFile);
+
+                if (json == null)
+                    throw new InvalidOperationException(
+                        "contentstack_utils: regions.json not found and could not be downloaded. " +
+                        "Run 'dotnet run Scripts/refresh-region.cs' and ensure network access.");
+
+                JsonDocument doc;
+                try
+                {
+                    doc = JsonDocument.Parse(json);
+                }
+                catch (JsonException ex)
+                {
+                    throw new InvalidOperationException(
+                        "contentstack_utils: regions.json is corrupt. " +
+                        "Run 'dotnet run Scripts/refresh-region.cs' to re-download it.", ex);
+                }
+
+                if (!doc.RootElement.TryGetProperty("regions", out var regionsEl) ||
+                    regionsEl.ValueKind != JsonValueKind.Array)
+                {
+                    throw new InvalidOperationException(
+                        "contentstack_utils: regions.json is corrupt. " +
+                        "Run 'dotnet run Scripts/refresh-region.cs' to re-download it.");
+                }
+
+                var list = new List<JsonElement>();
+                foreach (var r in regionsEl.EnumerateArray())
+                    list.Add(r.Clone());
+
+                _regionsData = list.ToArray();
+                return _regionsData;
+            }
+        }
+
+        /// <summary>
+        /// Returns the path to regions.json next to the DLL 
+        /// </summary>
+        internal static string GetLocalFilePath()
+        {
+            string assemblyDir = Path.GetDirectoryName(typeof(Endpoint).Assembly.Location)
+                                 ?? AppContext.BaseDirectory;
+            return Path.Combine(assemblyDir, "Assets", "regions.json");
+        }
+
+        /// <summary>
+        /// Reads regions.json from disk. Returns null if the file does not exist.
+        /// </summary>
+        private static string? ReadLocalFile(string path)
+        {
+            if (!File.Exists(path))
+                return null;
+            try
+            {
+                return File.ReadAllText(path);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Downloads regions.json from the CDN and writes it to disk so that future
+        /// process startups read from the local file instead of downloading again.
+        /// Silent on all failures (network error, permission denied).
+        /// </summary>
+        private static string? DownloadAndSave(string dest)
+        {
+            try
+            {
+                var task = _httpClient.GetStringAsync(RegionsUrl);
+                task.Wait();
+                string data = task.Result;
+
+                using var doc = JsonDocument.Parse(data);
+                if (!doc.RootElement.TryGetProperty("regions", out _))
+                    return null;
+
+                // Write to disk — next startup reads from local file (Step 2).
+                // Silent on PermissionError or read-only filesystem
+                try
+                {
+                    Directory.CreateDirectory(Path.GetDirectoryName(dest)!);
+                    File.WriteAllText(dest, data);
+                }
+                catch { }
+
+                return data;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Two-pass region lookup: ID match wins over alias match.
+        /// Input must already be lowercased and trimmed.
+        /// </summary>
+        private static JsonElement? FindRegion(JsonElement[] regions, string normalized)
+        {
+            // Pass 1 — exact id match
+            foreach (var r in regions)
+            {
+                if (r.TryGetProperty("id", out var id) &&
+                    id.GetString()?.ToLowerInvariant() == normalized)
+                    return r;
+            }
+
+            // Pass 2 — alias match
+            foreach (var r in regions)
+            {
+                if (!r.TryGetProperty("alias", out var aliases)) continue;
+                foreach (var alias in aliases.EnumerateArray())
+                {
+                    if (alias.GetString()?.ToLowerInvariant() == normalized)
+                        return r;
+                }
+            }
+
+            return null;
+        }
+
+        private static string StripHttps(string url)
+        {
+            return Regex.Replace(url, @"^https?://", string.Empty);
+        }
+    }
+}

--- a/Contentstack.Utils/Utils.cs
+++ b/Contentstack.Utils/Utils.cs
@@ -434,5 +434,19 @@ namespace Contentstack.Utils
             }
             return variantArray;
         }
+
+        /// <summary>
+        /// Resolves a single Contentstack service endpoint URL for the given region.
+        /// Proxy for <see cref="Endpoints.Endpoint.GetContentstackEndpoint(string, string, bool)"/>.
+        /// </summary>
+        public static string GetContentstackEndpoint(string region, string service, bool omitHttps = false)
+            => Endpoints.Endpoint.GetContentstackEndpoint(region, service, omitHttps);
+
+        /// <summary>
+        /// Returns all service endpoint URLs for the given region.
+        /// Proxy for <see cref="Endpoints.Endpoint.GetContentstackEndpoint(string, bool)"/>.
+        /// </summary>
+        public static Dictionary<string, string> GetContentstackEndpoint(string region, bool omitHttps = false)
+            => Endpoints.Endpoint.GetContentstackEndpoint(region, omitHttps);
     }
 }

--- a/Scripts/refresh-region.cs
+++ b/Scripts/refresh-region.cs
@@ -1,0 +1,77 @@
+// Refresh regions.json from the Contentstack CDN.
+//
+// Works for both SDK developers and SDK consumers — no file copying needed.
+// NuGet automatically places this file in your project's Scripts/ folder
+// when you install the contentstack.utils package.
+//
+// Usage (run from your project root after dotnet build):
+//   dotnet run Scripts/refresh-region.cs
+//
+// Run whenever Contentstack adds a new region or service.
+
+using System.IO;
+using System.Net.Http;
+using System.Text.Json;
+
+const string RegionsUrl = "https://artifacts.contentstack.com/regions.json";
+
+string root = Directory.GetCurrentDirectory();
+
+Console.WriteLine($"Fetching {RegionsUrl} ...");
+
+string json;
+try
+{
+    using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
+    json = await http.GetStringAsync(RegionsUrl);
+}
+catch (Exception ex)
+{
+    Console.Error.WriteLine($"ERROR: Could not download regions.json: {ex.Message}");
+    return 1;
+}
+
+JsonDocument doc;
+try
+{
+    doc = JsonDocument.Parse(json);
+}
+catch (JsonException ex)
+{
+    Console.Error.WriteLine($"ERROR: Downloaded content is not valid JSON: {ex.Message}");
+    return 1;
+}
+
+if (!doc.RootElement.TryGetProperty("regions", out var regionsEl))
+{
+    Console.Error.WriteLine("ERROR: Downloaded JSON does not contain a 'regions' key.");
+    return 1;
+}
+
+int regionCount = regionsEl.GetArrayLength();
+
+// ── 1. All bin output dirs — finds every Contentstack.Utils.dll in bin/ ───
+// Works for both the SDK repo and consumer projects after dotnet build.
+// Writes Assets/regions.json next to each DLL found.
+int binCount = 0;
+foreach (string dll in Directory.GetFiles(root, "Contentstack.Utils.dll", SearchOption.AllDirectories))
+{
+    if (!dll.Contains(Path.DirectorySeparatorChar + "bin" + Path.DirectorySeparatorChar))
+        continue;
+
+    string binDest = Path.Combine(Path.GetDirectoryName(dll)!, "Assets", "regions.json");
+    await WriteFile(binDest, json);
+    Console.WriteLine($"[bin]    Wrote {regionCount} regions → {binDest}");
+    binCount++;
+}
+
+if (binCount == 0)
+    Console.WriteLine("[bin]    No build output found — run 'dotnet build' first, then re-run this script.");
+
+return 0;
+
+static async Task WriteFile(string path, string content)
+{
+    Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+    await File.WriteAllTextAsync(path, content);
+}

--- a/build/contentstack.utils.targets
+++ b/build/contentstack.utils.targets
@@ -1,0 +1,19 @@
+<Project>
+  <!--
+    Copies refresh-region.cs into the consuming project's Scripts/ folder
+    on first build. Customer then runs:
+      dotnet run Scripts/refresh-region.cs
+  -->
+  <PropertyGroup>
+    <_RefreshScriptDest>$(MSBuildProjectDirectory)/Scripts/refresh-region.cs</_RefreshScriptDest>
+    <_RefreshScriptSrc>$(MSBuildThisFileDirectory)../contentFiles/cs/any/Scripts/refresh-region.cs</_RefreshScriptSrc>
+  </PropertyGroup>
+
+  <Target Name="ContentstackUtils_PlaceRefreshScript"
+          AfterTargets="ResolvePackageDependenciesForBuild"
+          Condition="!Exists('$(_RefreshScriptDest)')">
+    <MakeDir Directories="$(MSBuildProjectDirectory)/Scripts" />
+    <Copy SourceFiles="$(_RefreshScriptSrc)" DestinationFiles="$(_RefreshScriptDest)" />
+    <Message Text="contentstack.utils: Scripts/refresh-region.cs added to your project. Run 'dotnet run Scripts/refresh-region.cs' to refresh regions." Importance="High" />
+  </Target>
+</Project>


### PR DESCRIPTION
## Summary

- Adds `Endpoint.GetContentstackEndpoint(region, service)` for resolving
  Contentstack service URLs across all 7 regions (NA, EU, AU, Azure-NA,
  Azure-EU, GCP-NA, GCP-EU) and 18 service keys
- `regions.json` registry auto-downloads from CDN on first use and caches
  on disk — SDK self-heals if the file is missing, no setup required
- `Scripts/refresh-region.cs` bundled in the NuGet package — placed in
  `Scripts/` on first `dotnet build`, run anytime to pull latest regions
- `Utils.GetContentstackEndpoint(...)` proxy added for convenience
- Case-insensitive region alias support (`"us"`, `"AWS-NA"`, `"azure_na"`)
- `omitHttps` flag for SDK host configuration

## Test plan

- [ ] `dotnet test --filter "FullyQualifiedName~EndpointTest"` — 44 unit tests pass
- [ ] `dotnet run Scripts/refresh-region.cs` from repo root —  All bin dirs
