### PR TITLE
fix: add EmbeddedObject and EmbeddedObjectConverter to resolve IEmbeddedObject deserialization failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### Version: 1.3.1
+#### Date: June-23-2026
+- Added `EmbeddedObject` as a concrete implementation of `IEmbeddedObject`, covering both `IEmbeddedEntry` and `IEmbeddedAsset`.
+- Added `EmbeddedObjectConverter` to resolve `IEmbeddedObject` during JSON deserialization without requiring changes in consumer code.
+- Custom fields on embedded entries and assets are preserved via `[JsonExtensionData]`.
+
 ### Version: 1.3.0
 
 #### Date: May-11-2026

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### Version: 1.3.1
+### Version: 1.4.0
 #### Date: June-23-2026
 - Added `EmbeddedObject` as a concrete implementation of `IEmbeddedObject`, covering both `IEmbeddedEntry` and `IEmbeddedAsset`.
 - Added `EmbeddedObjectConverter` to resolve `IEmbeddedObject` during JSON deserialization without requiring changes in consumer code.

--- a/Contentstack.Utils.Tests/EmbeddedObjectConverterTest.cs
+++ b/Contentstack.Utils.Tests/EmbeddedObjectConverterTest.cs
@@ -1,0 +1,284 @@
+using System;
+using System.Collections.Generic;
+using Contentstack.Utils.Converters;
+using Contentstack.Utils.Interfaces;
+using Contentstack.Utils.Models;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Contentstack.Utils.Tests
+{
+    public class EmbeddedObjectConverterTest
+    {
+        private readonly EmbeddedObjectConverter _converter = new EmbeddedObjectConverter();
+
+        // ── JSON fixtures ─────────────────────────────────────────────────────
+
+        private const string EntryJson = @"{
+            ""uid"": ""blt123"",
+            ""_content_type_uid"": ""author"",
+            ""title"": ""John Smith"",
+            ""bio"": ""Senior engineer"",
+            ""email"": ""john@example.com""
+        }";
+
+        private const string AssetJson = @"{
+            ""uid"": ""bltasset456"",
+            ""_content_type_uid"": ""sys_assets"",
+            ""filename"": ""photo.jpg"",
+            ""url"": ""https://cdn.example.com/photo.jpg""
+        }";
+
+        private const string EmbeddedItemsJson = @"[
+            {
+                ""uid"": ""blt111"",
+                ""_content_type_uid"": ""author"",
+                ""title"": ""Alice"",
+                ""bio"": ""Tech lead""
+            },
+            {
+                ""uid"": ""blt222"",
+                ""_content_type_uid"": ""sys_assets"",
+                ""filename"": ""logo.png"",
+                ""url"": ""https://cdn.example.com/logo.png""
+            }
+        ]";
+
+        // ── EmbeddedObjectConverter.CanConvert ────────────────────────────────
+
+        [Fact]
+        public void CanConvert_IEmbeddedObject_ReturnsTrue()
+        {
+            Assert.True(_converter.CanConvert(typeof(IEmbeddedObject)));
+        }
+
+        [Fact]
+        public void CanConvert_IEmbeddedEntry_ReturnsFalse()
+        {
+            // Converter must not intercept the sub-interfaces — only the bare IEmbeddedObject.
+            Assert.False(_converter.CanConvert(typeof(IEmbeddedEntry)));
+        }
+
+        [Fact]
+        public void CanConvert_IEmbeddedAsset_ReturnsFalse()
+        {
+            Assert.False(_converter.CanConvert(typeof(IEmbeddedAsset)));
+        }
+
+        [Fact]
+        public void CanConvert_EmbeddedObject_ReturnsFalse()
+        {
+            // Concrete class must fall through to Newtonsoft default mapping.
+            Assert.False(_converter.CanConvert(typeof(EmbeddedObject)));
+        }
+
+        [Fact]
+        public void CanConvert_CustomerSubclass_ReturnsFalse()
+        {
+            // Customer-defined subclasses must not be intercepted.
+            Assert.False(_converter.CanConvert(typeof(CustomerDefinedEmbeddedObject)));
+        }
+
+        [Fact]
+        public void CanWrite_IsFalse()
+        {
+            Assert.False(_converter.CanWrite);
+        }
+
+        // ── EmbeddedObjectConverter.WriteJson ─────────────────────────────────
+
+        [Fact]
+        public void WriteJson_ThrowsNotSupportedException()
+        {
+            Assert.Throws<NotSupportedException>(() =>
+                _converter.WriteJson(null, new EmbeddedObject(), new JsonSerializer()));
+        }
+
+        // ── EmbeddedObjectConverter.ReadJson ─────────────────────────────────
+
+        [Fact]
+        public void ReadJson_NullToken_ReturnsNull()
+        {
+            var settings = SettingsWithConverter();
+            var result = JsonConvert.DeserializeObject<IEmbeddedObject>("null", settings);
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void ReadJson_ValidEntryJson_ReturnsEmbeddedObject()
+        {
+            var settings = SettingsWithConverter();
+            var result = JsonConvert.DeserializeObject<IEmbeddedObject>(EntryJson, settings);
+            Assert.NotNull(result);
+            Assert.IsType<EmbeddedObject>(result);
+        }
+
+        [Fact]
+        public void ReadJson_PopulatesUid()
+        {
+            var result = DeserializeEntry(EntryJson);
+            Assert.Equal("blt123", result.Uid);
+        }
+
+        [Fact]
+        public void ReadJson_PopulatesContentTypeUid()
+        {
+            var result = DeserializeEntry(EntryJson);
+            Assert.Equal("author", result.ContentTypeUid);
+        }
+
+        [Fact]
+        public void ReadJson_PopulatesTitle_ViaIEmbeddedEntry()
+        {
+            var result = DeserializeEntry(EntryJson);
+            var asEntry = result as IEmbeddedEntry;
+            Assert.NotNull(asEntry);
+            Assert.Equal("John Smith", asEntry.Title);
+        }
+
+        [Fact]
+        public void ReadJson_PopulatesFileName_ViaIEmbeddedAsset()
+        {
+            var result = DeserializeEntry(AssetJson);
+            var asAsset = result as IEmbeddedAsset;
+            Assert.NotNull(asAsset);
+            Assert.Equal("photo.jpg", asAsset.FileName);
+            Assert.Equal("https://cdn.example.com/photo.jpg", asAsset.Url);
+        }
+
+        [Fact]
+        public void ReadJson_CustomFields_CapturedViaExtensionData()
+        {
+            // bio and email are not declared on EmbeddedObject — they must land in Fields.
+            var result = DeserializeEntry(EntryJson);
+            Assert.NotNull(result.Fields);
+            Assert.True(result.Fields.ContainsKey("bio"));
+            Assert.True(result.Fields.ContainsKey("email"));
+            Assert.Equal("Senior engineer", result.Fields["bio"].ToString());
+            Assert.Equal("john@example.com", result.Fields["email"].ToString());
+        }
+
+        [Fact]
+        public void ReadJson_KnownFields_NotDuplicatedInExtensionData()
+        {
+            // uid, _content_type_uid, title are declared — they must NOT appear in Fields.
+            var result = DeserializeEntry(EntryJson);
+            Assert.False(result.Fields.ContainsKey("uid"));
+            Assert.False(result.Fields.ContainsKey("_content_type_uid"));
+            Assert.False(result.Fields.ContainsKey("title"));
+        }
+
+        [Fact]
+        public void ReadJson_NoCustomFields_FieldsIsEmpty()
+        {
+            var json = @"{ ""uid"": ""blt1"", ""_content_type_uid"": ""author"", ""title"": ""T"" }";
+            var result = DeserializeEntry(json);
+            Assert.Empty(result.Fields);
+        }
+
+        // ── Integration — List<IEmbeddedObject> deserialization ───────────────
+
+        [Fact]
+        public void Deserialize_ListOfIEmbeddedObject_WithConverter_Succeeds()
+        {
+            var settings = SettingsWithConverter();
+            var result = JsonConvert.DeserializeObject<List<IEmbeddedObject>>(EmbeddedItemsJson, settings);
+            Assert.NotNull(result);
+            Assert.Equal(2, result.Count);
+            Assert.All(result, item => Assert.IsType<EmbeddedObject>(item));
+        }
+
+        [Fact]
+        public void Deserialize_ListOfIEmbeddedObject_WithoutConverter_ThrowsJsonSerializationException()
+        {
+            // Reproduces the customer crash on contentstack.csharp v2.27.0.
+            Assert.Throws<JsonSerializationException>(() =>
+                JsonConvert.DeserializeObject<List<IEmbeddedObject>>(EmbeddedItemsJson));
+        }
+
+        [Fact]
+        public void Deserialize_ListOfIEmbeddedObject_FirstItem_HasCorrectFields()
+        {
+            var settings = SettingsWithConverter();
+            var result = JsonConvert.DeserializeObject<List<IEmbeddedObject>>(EmbeddedItemsJson, settings);
+            var first = result[0] as EmbeddedObject;
+            Assert.Equal("blt111", first.Uid);
+            Assert.Equal("author", first.ContentTypeUid);
+            Assert.Equal("Alice", first.Title);
+            Assert.Equal("Tech lead", first.Fields["bio"].ToString());
+        }
+
+        [Fact]
+        public void Deserialize_ListOfIEmbeddedObject_SecondItem_IsAsset()
+        {
+            var settings = SettingsWithConverter();
+            var result = JsonConvert.DeserializeObject<List<IEmbeddedObject>>(EmbeddedItemsJson, settings);
+            var second = result[1] as EmbeddedObject;
+            Assert.Equal("blt222", second.Uid);
+            Assert.Equal("logo.png", second.FileName);
+            Assert.Equal("https://cdn.example.com/logo.png", second.Url);
+        }
+
+        // ── EmbeddedObject defaults ───────────────────────────────────────────
+
+        [Fact]
+        public void EmbeddedObject_DefaultValues_AreEmptyStrings()
+        {
+            var obj = new EmbeddedObject();
+            Assert.Equal(string.Empty, obj.Uid);
+            Assert.Equal(string.Empty, obj.ContentTypeUid);
+            Assert.Equal(string.Empty, obj.Title);
+            Assert.Equal(string.Empty, obj.FileName);
+            Assert.Equal(string.Empty, obj.Url);
+        }
+
+        [Fact]
+        public void EmbeddedObject_Fields_DefaultsToEmptyDictionary()
+        {
+            var obj = new EmbeddedObject();
+            Assert.NotNull(obj.Fields);
+            Assert.Empty(obj.Fields);
+        }
+
+        [Fact]
+        public void EmbeddedObject_ImplementsIEmbeddedEntry()
+        {
+            Assert.True(typeof(IEmbeddedEntry).IsAssignableFrom(typeof(EmbeddedObject)));
+        }
+
+        [Fact]
+        public void EmbeddedObject_ImplementsIEmbeddedAsset()
+        {
+            Assert.True(typeof(IEmbeddedAsset).IsAssignableFrom(typeof(EmbeddedObject)));
+        }
+
+        [Fact]
+        public void EmbeddedObject_ImplementsIEmbeddedObject()
+        {
+            Assert.True(typeof(IEmbeddedObject).IsAssignableFrom(typeof(EmbeddedObject)));
+        }
+
+        // ── Helpers ───────────────────────────────────────────────────────────
+
+        private static JsonSerializerSettings SettingsWithConverter()
+        {
+            var settings = new JsonSerializerSettings();
+            settings.Converters.Add(new EmbeddedObjectConverter());
+            return settings;
+        }
+
+        private static EmbeddedObject DeserializeEntry(string json)
+        {
+            var settings = SettingsWithConverter();
+            return (EmbeddedObject)JsonConvert.DeserializeObject<IEmbeddedObject>(json, settings);
+        }
+
+        // Customer-defined subclass — used to verify CanConvert does not over-intercept.
+        private class CustomerDefinedEmbeddedObject : IEmbeddedObject
+        {
+            public string Uid { get; set; }
+            public string ContentTypeUid { get; set; }
+        }
+    }
+}

--- a/Contentstack.Utils.Tests/EmbeddedObjectConverterTest.cs
+++ b/Contentstack.Utils.Tests/EmbeddedObjectConverterTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using Contentstack.Utils.Converters;
 using Contentstack.Utils.Interfaces;
 using Contentstack.Utils.Models;
@@ -13,37 +14,26 @@ namespace Contentstack.Utils.Tests
     {
         private readonly EmbeddedObjectConverter _converter = new EmbeddedObjectConverter();
 
-        // ── JSON fixtures ─────────────────────────────────────────────────────
+        // ── JSON file loader (mirrors VariantAliasesTest pattern) ─────────────
 
-        private const string EntryJson = @"{
-            ""uid"": ""blt123"",
-            ""_content_type_uid"": ""author"",
-            ""title"": ""John Smith"",
-            ""bio"": ""Senior engineer"",
-            ""email"": ""john@example.com""
-        }";
+        private static string ReadJson(string fileName)
+        {
+            var path = Path.Combine(AppContext.BaseDirectory, "Resources", fileName);
+            return File.ReadAllText(path);
+        }
 
-        private const string AssetJson = @"{
-            ""uid"": ""bltasset456"",
-            ""_content_type_uid"": ""sys_assets"",
-            ""filename"": ""photo.jpg"",
-            ""url"": ""https://cdn.example.com/photo.jpg""
-        }";
+        private static JsonSerializerSettings SettingsWithConverter()
+        {
+            var settings = new JsonSerializerSettings();
+            settings.Converters.Add(new EmbeddedObjectConverter());
+            return settings;
+        }
 
-        private const string EmbeddedItemsJson = @"[
-            {
-                ""uid"": ""blt111"",
-                ""_content_type_uid"": ""author"",
-                ""title"": ""Alice"",
-                ""bio"": ""Tech lead""
-            },
-            {
-                ""uid"": ""blt222"",
-                ""_content_type_uid"": ""sys_assets"",
-                ""filename"": ""logo.png"",
-                ""url"": ""https://cdn.example.com/logo.png""
-            }
-        ]";
+        private static EmbeddedObject DeserializeSingle(string json)
+        {
+            return (EmbeddedObject)JsonConvert.DeserializeObject<IEmbeddedObject>(
+                json, SettingsWithConverter());
+        }
 
         // ── EmbeddedObjectConverter.CanConvert ────────────────────────────────
 
@@ -69,7 +59,7 @@ namespace Contentstack.Utils.Tests
         [Fact]
         public void CanConvert_EmbeddedObject_ReturnsFalse()
         {
-            // Concrete class must fall through to Newtonsoft default mapping.
+            // Concrete class must fall through to Newtonsoft default property mapping.
             Assert.False(_converter.CanConvert(typeof(EmbeddedObject)));
         }
 
@@ -95,97 +85,147 @@ namespace Contentstack.Utils.Tests
                 _converter.WriteJson(null, new EmbeddedObject(), new JsonSerializer()));
         }
 
-        // ── EmbeddedObjectConverter.ReadJson ─────────────────────────────────
+        // ── ReadJson — null token ─────────────────────────────────────────────
 
         [Fact]
         public void ReadJson_NullToken_ReturnsNull()
         {
-            var settings = SettingsWithConverter();
-            var result = JsonConvert.DeserializeObject<IEmbeddedObject>("null", settings);
+            var result = JsonConvert.DeserializeObject<IEmbeddedObject>("null", SettingsWithConverter());
             Assert.Null(result);
         }
 
+        // ── ReadJson — single embedded entry (embeddedEntry.json) ────────────
+
         [Fact]
-        public void ReadJson_ValidEntryJson_ReturnsEmbeddedObject()
+        public void ReadJson_EntryJson_ReturnsEmbeddedObject()
         {
-            var settings = SettingsWithConverter();
-            var result = JsonConvert.DeserializeObject<IEmbeddedObject>(EntryJson, settings);
+            var result = JsonConvert.DeserializeObject<IEmbeddedObject>(
+                ReadJson("embeddedEntry.json"), SettingsWithConverter());
             Assert.NotNull(result);
             Assert.IsType<EmbeddedObject>(result);
         }
 
         [Fact]
-        public void ReadJson_PopulatesUid()
+        public void ReadJson_EntryJson_PopulatesUid()
         {
-            var result = DeserializeEntry(EntryJson);
-            Assert.Equal("blt123", result.Uid);
+            var result = DeserializeSingle(ReadJson("embeddedEntry.json"));
+            Assert.Equal("blt05dca76dadb9455e", result.Uid);
         }
 
         [Fact]
-        public void ReadJson_PopulatesContentTypeUid()
+        public void ReadJson_EntryJson_PopulatesContentTypeUid()
         {
-            var result = DeserializeEntry(EntryJson);
+            var result = DeserializeSingle(ReadJson("embeddedEntry.json"));
             Assert.Equal("author", result.ContentTypeUid);
         }
 
         [Fact]
-        public void ReadJson_PopulatesTitle_ViaIEmbeddedEntry()
+        public void ReadJson_EntryJson_PopulatesTitle_ViaIEmbeddedEntry()
         {
-            var result = DeserializeEntry(EntryJson);
-            var asEntry = result as IEmbeddedEntry;
-            Assert.NotNull(asEntry);
-            Assert.Equal("John Smith", asEntry.Title);
+            var result = DeserializeSingle(ReadJson("embeddedEntry.json"));
+            Assert.Equal("John Smith", (result as IEmbeddedEntry)?.Title);
         }
 
         [Fact]
-        public void ReadJson_PopulatesFileName_ViaIEmbeddedAsset()
+        public void ReadJson_EntryJson_CustomFields_CapturedInFields()
         {
-            var result = DeserializeEntry(AssetJson);
-            var asAsset = result as IEmbeddedAsset;
-            Assert.NotNull(asAsset);
-            Assert.Equal("photo.jpg", asAsset.FileName);
-            Assert.Equal("https://cdn.example.com/photo.jpg", asAsset.Url);
-        }
-
-        [Fact]
-        public void ReadJson_CustomFields_CapturedViaExtensionData()
-        {
-            // bio and email are not declared on EmbeddedObject — they must land in Fields.
-            var result = DeserializeEntry(EntryJson);
-            Assert.NotNull(result.Fields);
+            var result = DeserializeSingle(ReadJson("embeddedEntry.json"));
             Assert.True(result.Fields.ContainsKey("bio"));
             Assert.True(result.Fields.ContainsKey("email"));
-            Assert.Equal("Senior engineer", result.Fields["bio"].ToString());
-            Assert.Equal("john@example.com", result.Fields["email"].ToString());
+            Assert.True(result.Fields.ContainsKey("avatar_url"));
+            Assert.Equal(
+                "Senior software engineer with 12 years of experience in distributed systems.",
+                result.Fields["bio"].ToString());
+            Assert.Equal("john.smith@example.com", result.Fields["email"].ToString());
         }
 
         [Fact]
-        public void ReadJson_KnownFields_NotDuplicatedInExtensionData()
+        public void ReadJson_EntryJson_NestedObjectField_CapturedInFields()
         {
-            // uid, _content_type_uid, title are declared — they must NOT appear in Fields.
-            var result = DeserializeEntry(EntryJson);
+            // social is a nested object — must land in Fields as a JObject, not be dropped.
+            var result = DeserializeSingle(ReadJson("embeddedEntry.json"));
+            Assert.True(result.Fields.ContainsKey("social"));
+            var social = result.Fields["social"] as JObject;
+            Assert.NotNull(social);
+            Assert.Equal("@johnsmith", social["twitter"]?.ToString());
+            Assert.Equal("linkedin.com/in/johnsmith", social["linkedin"]?.ToString());
+        }
+
+        [Fact]
+        public void ReadJson_EntryJson_ArrayField_CapturedInFields()
+        {
+            // tags is a JSON array — must land in Fields as a JArray.
+            var result = DeserializeSingle(ReadJson("embeddedEntry.json"));
+            Assert.True(result.Fields.ContainsKey("tags"));
+            var tags = result.Fields["tags"] as JArray;
+            Assert.NotNull(tags);
+            Assert.Equal(3, tags.Count);
+            Assert.Contains("dotnet", tags.ToObject<List<string>>());
+        }
+
+        [Fact]
+        public void ReadJson_EntryJson_KnownFields_NotDuplicatedInExtensionData()
+        {
+            // uid, _content_type_uid, title are declared properties — must NOT appear in Fields.
+            var result = DeserializeSingle(ReadJson("embeddedEntry.json"));
             Assert.False(result.Fields.ContainsKey("uid"));
             Assert.False(result.Fields.ContainsKey("_content_type_uid"));
             Assert.False(result.Fields.ContainsKey("title"));
         }
 
+        // ── ReadJson — single embedded asset (embeddedAsset.json) ────────────
+
         [Fact]
-        public void ReadJson_NoCustomFields_FieldsIsEmpty()
+        public void ReadJson_AssetJson_PopulatesFileName_ViaIEmbeddedAsset()
         {
-            var json = @"{ ""uid"": ""blt1"", ""_content_type_uid"": ""author"", ""title"": ""T"" }";
-            var result = DeserializeEntry(json);
-            Assert.Empty(result.Fields);
+            var result = DeserializeSingle(ReadJson("embeddedAsset.json"));
+            var asAsset = result as IEmbeddedAsset;
+            Assert.NotNull(asAsset);
+            Assert.Equal("team-photo-2026.jpg", asAsset.FileName);
         }
 
-        // ── Integration — List<IEmbeddedObject> deserialization ───────────────
+        [Fact]
+        public void ReadJson_AssetJson_PopulatesUrl()
+        {
+            var result = DeserializeSingle(ReadJson("embeddedAsset.json"));
+            Assert.Contains("team-photo-2026.jpg", result.Url);
+        }
+
+        [Fact]
+        public void ReadJson_AssetJson_ContentTypeUid_IsSysAssets()
+        {
+            var result = DeserializeSingle(ReadJson("embeddedAsset.json"));
+            Assert.Equal("sys_assets", result.ContentTypeUid);
+        }
+
+        [Fact]
+        public void ReadJson_AssetJson_DimensionObject_CapturedInFields()
+        {
+            var result = DeserializeSingle(ReadJson("embeddedAsset.json"));
+            Assert.True(result.Fields.ContainsKey("dimension"));
+            var dimension = result.Fields["dimension"] as JObject;
+            Assert.NotNull(dimension);
+            Assert.Equal(1080, dimension["height"]?.Value<int>());
+            Assert.Equal(1920, dimension["width"]?.Value<int>());
+        }
+
+        [Fact]
+        public void ReadJson_AssetJson_FileSize_CapturedInFields()
+        {
+            var result = DeserializeSingle(ReadJson("embeddedAsset.json"));
+            Assert.True(result.Fields.ContainsKey("file_size"));
+            Assert.Equal("284521", result.Fields["file_size"].ToString());
+        }
+
+        // ── Integration — List<IEmbeddedObject> (embeddedItems.json) ─────────
 
         [Fact]
         public void Deserialize_ListOfIEmbeddedObject_WithConverter_Succeeds()
         {
-            var settings = SettingsWithConverter();
-            var result = JsonConvert.DeserializeObject<List<IEmbeddedObject>>(EmbeddedItemsJson, settings);
+            var result = JsonConvert.DeserializeObject<List<IEmbeddedObject>>(
+                ReadJson("embeddedItems.json"), SettingsWithConverter());
             Assert.NotNull(result);
-            Assert.Equal(2, result.Count);
+            Assert.Equal(3, result.Count);
             Assert.All(result, item => Assert.IsType<EmbeddedObject>(item));
         }
 
@@ -194,33 +234,123 @@ namespace Contentstack.Utils.Tests
         {
             // Reproduces the customer crash on contentstack.csharp v2.27.0.
             Assert.Throws<JsonSerializationException>(() =>
-                JsonConvert.DeserializeObject<List<IEmbeddedObject>>(EmbeddedItemsJson));
+                JsonConvert.DeserializeObject<List<IEmbeddedObject>>(ReadJson("embeddedItems.json")));
         }
 
         [Fact]
-        public void Deserialize_ListOfIEmbeddedObject_FirstItem_HasCorrectFields()
+        public void Deserialize_ListItem_Entry_HasCorrectKnownFields()
         {
-            var settings = SettingsWithConverter();
-            var result = JsonConvert.DeserializeObject<List<IEmbeddedObject>>(EmbeddedItemsJson, settings);
-            var first = result[0] as EmbeddedObject;
-            Assert.Equal("blt111", first.Uid);
-            Assert.Equal("author", first.ContentTypeUid);
-            Assert.Equal("Alice", first.Title);
-            Assert.Equal("Tech lead", first.Fields["bio"].ToString());
+            var result = JsonConvert.DeserializeObject<List<IEmbeddedObject>>(
+                ReadJson("embeddedItems.json"), SettingsWithConverter());
+            var entry = result[0] as EmbeddedObject;
+            Assert.Equal("blt05dca76dadb9455e", entry.Uid);
+            Assert.Equal("author", entry.ContentTypeUid);
+            Assert.Equal("John Smith", entry.Title);
         }
 
         [Fact]
-        public void Deserialize_ListOfIEmbeddedObject_SecondItem_IsAsset()
+        public void Deserialize_ListItem_Entry_HasCustomFields()
         {
-            var settings = SettingsWithConverter();
-            var result = JsonConvert.DeserializeObject<List<IEmbeddedObject>>(EmbeddedItemsJson, settings);
-            var second = result[1] as EmbeddedObject;
-            Assert.Equal("blt222", second.Uid);
-            Assert.Equal("logo.png", second.FileName);
-            Assert.Equal("https://cdn.example.com/logo.png", second.Url);
+            var result = JsonConvert.DeserializeObject<List<IEmbeddedObject>>(
+                ReadJson("embeddedItems.json"), SettingsWithConverter());
+            var entry = result[0] as EmbeddedObject;
+            Assert.Equal("john.smith@example.com", entry.Fields["email"].ToString());
+            Assert.Equal("https://cdn.example.com/authors/john-smith.jpg",
+                entry.Fields["avatar_url"].ToString());
         }
 
-        // ── EmbeddedObject defaults ───────────────────────────────────────────
+        [Fact]
+        public void Deserialize_ListItem_FirstAsset_HasCorrectFields()
+        {
+            var result = JsonConvert.DeserializeObject<List<IEmbeddedObject>>(
+                ReadJson("embeddedItems.json"), SettingsWithConverter());
+            var asset = result[1] as EmbeddedObject;
+            Assert.Equal("blt61fc86ad844f4793", asset.Uid);
+            Assert.Equal("sys_assets", asset.ContentTypeUid);
+            Assert.Equal("team-photo-2026.jpg", asset.FileName);
+        }
+
+        [Fact]
+        public void Deserialize_ListItem_SecondAsset_HasCorrectFields()
+        {
+            var result = JsonConvert.DeserializeObject<List<IEmbeddedObject>>(
+                ReadJson("embeddedItems.json"), SettingsWithConverter());
+            var asset = result[2] as EmbeddedObject;
+            Assert.Equal("bltd80ed7f6d9d742ca", asset.Uid);
+            Assert.Equal("screenshot-2026-06-04.png", asset.FileName);
+        }
+
+        // ── Full entry deserialization (rteEntryWithEmbeddedItems.json) ───────
+        // Mirrors the actual Delivery API response shape: { "entry": { ..., "_embedded_items": { ... } } }
+
+        [Fact]
+        public void FullEntry_EmbeddedItems_DeserializesAllThreeItems()
+        {
+            var root = JObject.Parse(ReadJson("rteEntryWithEmbeddedItems.json"));
+            var embeddedItemsToken = root["entry"]["_embedded_items"]["rte_json"].ToString();
+
+            var result = JsonConvert.DeserializeObject<List<IEmbeddedObject>>(
+                embeddedItemsToken, SettingsWithConverter());
+
+            Assert.Equal(3, result.Count);
+        }
+
+        [Fact]
+        public void FullEntry_EmbeddedItems_FirstItem_IsAuthorEntry()
+        {
+            var root = JObject.Parse(ReadJson("rteEntryWithEmbeddedItems.json"));
+            var embeddedItemsToken = root["entry"]["_embedded_items"]["rte_json"].ToString();
+            var result = JsonConvert.DeserializeObject<List<IEmbeddedObject>>(
+                embeddedItemsToken, SettingsWithConverter());
+
+            var author = result[0] as EmbeddedObject;
+            Assert.Equal("author", author.ContentTypeUid);
+            Assert.Equal("John Smith", author.Title);
+            Assert.Equal("john.smith@example.com", author.Fields["email"].ToString());
+        }
+
+        [Fact]
+        public void FullEntry_EmbeddedItems_SecondAndThirdItems_AreAssets()
+        {
+            var root = JObject.Parse(ReadJson("rteEntryWithEmbeddedItems.json"));
+            var embeddedItemsToken = root["entry"]["_embedded_items"]["rte_json"].ToString();
+            var result = JsonConvert.DeserializeObject<List<IEmbeddedObject>>(
+                embeddedItemsToken, SettingsWithConverter());
+
+            Assert.Equal("sys_assets", (result[1] as EmbeddedObject)?.ContentTypeUid);
+            Assert.Equal("sys_assets", (result[2] as EmbeddedObject)?.ContentTypeUid);
+        }
+
+        [Fact]
+        public void FullEntry_EmbeddedItems_AssetDimension_CapturedInFields()
+        {
+            var root = JObject.Parse(ReadJson("rteEntryWithEmbeddedItems.json"));
+            var embeddedItemsToken = root["entry"]["_embedded_items"]["rte_json"].ToString();
+            var result = JsonConvert.DeserializeObject<List<IEmbeddedObject>>(
+                embeddedItemsToken, SettingsWithConverter());
+
+            var asset = result[1] as EmbeddedObject;
+            var dimension = asset.Fields["dimension"] as JObject;
+            Assert.NotNull(dimension);
+            Assert.Equal(1080, dimension["height"]?.Value<int>());
+            Assert.Equal(1920, dimension["width"]?.Value<int>());
+        }
+
+        [Fact]
+        public void FullEntry_EmbeddedItems_AuthorSocialObject_CapturedInFields()
+        {
+            var root = JObject.Parse(ReadJson("rteEntryWithEmbeddedItems.json"));
+            var embeddedItemsToken = root["entry"]["_embedded_items"]["rte_json"].ToString();
+            var result = JsonConvert.DeserializeObject<List<IEmbeddedObject>>(
+                embeddedItemsToken, SettingsWithConverter());
+
+            var author = result[0] as EmbeddedObject;
+            var social = author.Fields["social"] as JObject;
+            Assert.NotNull(social);
+            Assert.Equal("@johnsmith", social["twitter"]?.ToString());
+        }
+
+        // ── EmbeddedObject default state ──────────────────────────────────────
 
         [Fact]
         public void EmbeddedObject_DefaultValues_AreEmptyStrings()
@@ -259,22 +389,8 @@ namespace Contentstack.Utils.Tests
             Assert.True(typeof(IEmbeddedObject).IsAssignableFrom(typeof(EmbeddedObject)));
         }
 
-        // ── Helpers ───────────────────────────────────────────────────────────
+        // ── Customer-defined subclass (CanConvert isolation check) ────────────
 
-        private static JsonSerializerSettings SettingsWithConverter()
-        {
-            var settings = new JsonSerializerSettings();
-            settings.Converters.Add(new EmbeddedObjectConverter());
-            return settings;
-        }
-
-        private static EmbeddedObject DeserializeEntry(string json)
-        {
-            var settings = SettingsWithConverter();
-            return (EmbeddedObject)JsonConvert.DeserializeObject<IEmbeddedObject>(json, settings);
-        }
-
-        // Customer-defined subclass — used to verify CanConvert does not over-intercept.
         private class CustomerDefinedEmbeddedObject : IEmbeddedObject
         {
             public string Uid { get; set; }

--- a/Contentstack.Utils.Tests/Resources/embeddedAsset.json
+++ b/Contentstack.Utils.Tests/Resources/embeddedAsset.json
@@ -1,0 +1,22 @@
+{
+  "uid": "blt61fc86ad844f4793",
+  "_content_type_uid": "sys_assets",
+  "title": "Team Photo 2026",
+  "filename": "team-photo-2026.jpg",
+  "url": "https://cdn.contentstack.io/v3/assets/blt34775be4e6d8ab9c/blt61fc86ad844f4793/team-photo-2026.jpg",
+  "content_type": "image/jpeg",
+  "file_size": "284521",
+  "locale": "en-us",
+  "is_dir": false,
+  "tags": ["team", "photo", "2026"],
+  "dimension": {
+    "height": 1080,
+    "width": 1920
+  },
+  "publish_details": {
+    "environment": "development",
+    "locale": "en-us",
+    "time": "2026-06-15T10:00:00.000Z",
+    "user": "bltuser123"
+  }
+}

--- a/Contentstack.Utils.Tests/Resources/embeddedEntry.json
+++ b/Contentstack.Utils.Tests/Resources/embeddedEntry.json
@@ -1,0 +1,23 @@
+{
+  "uid": "blt05dca76dadb9455e",
+  "_content_type_uid": "author",
+  "title": "John Smith",
+  "locale": "en-us",
+  "_version": 3,
+  "created_at": "2026-06-01T09:00:00.000Z",
+  "updated_at": "2026-06-20T14:32:00.000Z",
+  "bio": "Senior software engineer with 12 years of experience in distributed systems.",
+  "email": "john.smith@example.com",
+  "avatar_url": "https://cdn.example.com/authors/john-smith.jpg",
+  "social": {
+    "twitter": "@johnsmith",
+    "linkedin": "linkedin.com/in/johnsmith"
+  },
+  "tags": ["engineering", "distributed-systems", "dotnet"],
+  "publish_details": {
+    "environment": "development",
+    "locale": "en-us",
+    "time": "2026-06-20T14:32:00.000Z",
+    "user": "bltuser123"
+  }
+}

--- a/Contentstack.Utils.Tests/Resources/embeddedItems.json
+++ b/Contentstack.Utils.Tests/Resources/embeddedItems.json
@@ -1,0 +1,67 @@
+[
+  {
+    "uid": "blt05dca76dadb9455e",
+    "_content_type_uid": "author",
+    "title": "John Smith",
+    "locale": "en-us",
+    "_version": 3,
+    "bio": "Senior software engineer with 12 years of experience in distributed systems.",
+    "email": "john.smith@example.com",
+    "avatar_url": "https://cdn.example.com/authors/john-smith.jpg",
+    "social": {
+      "twitter": "@johnsmith",
+      "linkedin": "linkedin.com/in/johnsmith"
+    },
+    "tags": ["engineering", "distributed-systems", "dotnet"],
+    "publish_details": {
+      "environment": "development",
+      "locale": "en-us",
+      "time": "2026-06-20T14:32:00.000Z",
+      "user": "bltuser123"
+    }
+  },
+  {
+    "uid": "blt61fc86ad844f4793",
+    "_content_type_uid": "sys_assets",
+    "title": "Team Photo 2026",
+    "filename": "team-photo-2026.jpg",
+    "url": "https://cdn.contentstack.io/v3/assets/blt34775be4e6d8ab9c/blt61fc86ad844f4793/team-photo-2026.jpg",
+    "content_type": "image/jpeg",
+    "file_size": "284521",
+    "locale": "en-us",
+    "is_dir": false,
+    "tags": ["team", "photo", "2026"],
+    "dimension": {
+      "height": 1080,
+      "width": 1920
+    },
+    "publish_details": {
+      "environment": "development",
+      "locale": "en-us",
+      "time": "2026-06-15T10:00:00.000Z",
+      "user": "bltuser123"
+    }
+  },
+  {
+    "uid": "bltd80ed7f6d9d742ca",
+    "_content_type_uid": "sys_assets",
+    "title": "Product Screenshot",
+    "filename": "screenshot-2026-06-04.png",
+    "url": "https://cdn.contentstack.io/v3/assets/blt34775be4e6d8ab9c/bltd80ed7f6d9d742ca/screenshot-2026-06-04.png",
+    "content_type": "image/png",
+    "file_size": "95340",
+    "locale": "en-us",
+    "is_dir": false,
+    "tags": ["screenshot", "product"],
+    "dimension": {
+      "height": 900,
+      "width": 1440
+    },
+    "publish_details": {
+      "environment": "development",
+      "locale": "en-us",
+      "time": "2026-06-10T08:00:00.000Z",
+      "user": "bltuser456"
+    }
+  }
+]

--- a/Contentstack.Utils.Tests/Resources/rteEntryWithEmbeddedItems.json
+++ b/Contentstack.Utils.Tests/Resources/rteEntryWithEmbeddedItems.json
@@ -1,0 +1,134 @@
+{
+  "entry": {
+    "uid": "blt17238fbf182d9cdb",
+    "_content_type_uid": "rte_json_comp",
+    "title": "Test RTE with Embedded Author",
+    "locale": "en-us",
+    "_version": 2,
+    "created_at": "2026-06-24T07:00:00.000Z",
+    "updated_at": "2026-06-24T08:00:00.000Z",
+    "author_name": "Grand & Toy Test",
+    "category": "SDK Testing",
+    "rte_json": {
+      "type": "doc",
+      "children": [
+        {
+          "type": "p",
+          "children": [
+            { "text": "Featured author: " },
+            {
+              "type": "reference",
+              "attrs": {
+                "type": "entry",
+                "entry-uid": "blt05dca76dadb9455e",
+                "content-type-uid": "author",
+                "locale": "en-us",
+                "display-type": "inline"
+              },
+              "children": [{ "text": "" }]
+            }
+          ]
+        },
+        {
+          "type": "p",
+          "children": [{ "text": "Team photo below:" }]
+        },
+        {
+          "type": "reference",
+          "attrs": {
+            "type": "asset",
+            "asset-uid": "blt61fc86ad844f4793",
+            "content-type-uid": "sys_assets",
+            "display-type": "display"
+          },
+          "children": [{ "text": "" }]
+        },
+        {
+          "type": "reference",
+          "attrs": {
+            "type": "asset",
+            "asset-uid": "bltd80ed7f6d9d742ca",
+            "content-type-uid": "sys_assets",
+            "display-type": "display"
+          },
+          "children": [{ "text": "" }]
+        }
+      ]
+    },
+    "_embedded_items": {
+      "rte_json": [
+        {
+          "uid": "blt05dca76dadb9455e",
+          "_content_type_uid": "author",
+          "title": "John Smith",
+          "locale": "en-us",
+          "_version": 3,
+          "bio": "Senior software engineer with 12 years of experience in distributed systems.",
+          "email": "john.smith@example.com",
+          "avatar_url": "https://cdn.example.com/authors/john-smith.jpg",
+          "social": {
+            "twitter": "@johnsmith",
+            "linkedin": "linkedin.com/in/johnsmith"
+          },
+          "tags": ["engineering", "distributed-systems", "dotnet"],
+          "publish_details": {
+            "environment": "development",
+            "locale": "en-us",
+            "time": "2026-06-20T14:32:00.000Z",
+            "user": "bltuser123"
+          }
+        },
+        {
+          "uid": "blt61fc86ad844f4793",
+          "_content_type_uid": "sys_assets",
+          "title": "Team Photo 2026",
+          "filename": "team-photo-2026.jpg",
+          "url": "https://cdn.contentstack.io/v3/assets/blt34775be4e6d8ab9c/blt61fc86ad844f4793/team-photo-2026.jpg",
+          "content_type": "image/jpeg",
+          "file_size": "284521",
+          "locale": "en-us",
+          "is_dir": false,
+          "tags": ["team", "photo", "2026"],
+          "dimension": {
+            "height": 1080,
+            "width": 1920
+          },
+          "publish_details": {
+            "environment": "development",
+            "locale": "en-us",
+            "time": "2026-06-15T10:00:00.000Z",
+            "user": "bltuser123"
+          }
+        },
+        {
+          "uid": "bltd80ed7f6d9d742ca",
+          "_content_type_uid": "sys_assets",
+          "title": "Product Screenshot",
+          "filename": "screenshot-2026-06-04.png",
+          "url": "https://cdn.contentstack.io/v3/assets/blt34775be4e6d8ab9c/bltd80ed7f6d9d742ca/screenshot-2026-06-04.png",
+          "content_type": "image/png",
+          "file_size": "95340",
+          "locale": "en-us",
+          "is_dir": false,
+          "tags": ["screenshot", "product"],
+          "dimension": {
+            "height": 900,
+            "width": 1440
+          },
+          "publish_details": {
+            "environment": "development",
+            "locale": "en-us",
+            "time": "2026-06-10T08:00:00.000Z",
+            "user": "bltuser456"
+          }
+        }
+      ]
+    },
+    "publish_details": {
+      "environment": "development",
+      "locale": "en-us",
+      "time": "2026-06-24T08:00:00.000Z",
+      "user": "bltuser123"
+    }
+  }
+}

--- a/Contentstack.Utils/Converters/EmbeddedObjectConverter.cs
+++ b/Contentstack.Utils/Converters/EmbeddedObjectConverter.cs
@@ -1,0 +1,34 @@
+using System;
+using Contentstack.Utils.Interfaces;
+using Contentstack.Utils.Models;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Contentstack.Utils.Converters
+{
+    // Resolves IEmbeddedObject to EmbeddedObject during deserialization.
+    // CanConvert uses exact type match so customer-defined subclasses are not intercepted.
+    public class EmbeddedObjectConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+            => objectType == typeof(IEmbeddedObject);
+
+        public override bool CanWrite => false;
+
+        public override object ReadJson(JsonReader reader, Type objectType,
+            object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Null)
+                return null;
+
+            var jo = JObject.Load(reader);
+            var result = new EmbeddedObject();
+            serializer.Populate(jo.CreateReader(), result);
+            return result;
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+            => throw new NotSupportedException(
+                "EmbeddedObjectConverter is read-only. Serialize EmbeddedObject directly.");
+    }
+}

--- a/Contentstack.Utils/Models/EmbeddedObject.cs
+++ b/Contentstack.Utils/Models/EmbeddedObject.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using Contentstack.Utils.Interfaces;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+namespace Contentstack.Utils.Models
+{
+    // Concrete class used by EmbeddedObjectConverter when deserializing _embedded_items.
+    // Implements both IEmbeddedEntry and IEmbeddedAsset to cover entries and assets.
+    public class EmbeddedObject : IEmbeddedEntry, IEmbeddedAsset
+    {
+        [JsonProperty("uid")]
+        public string Uid { get; set; } = string.Empty;
+
+        [JsonProperty("_content_type_uid")]
+        public string ContentTypeUid { get; set; } = string.Empty;
+
+        [JsonProperty("title")]
+        public string Title { get; set; } = string.Empty;
+
+        [JsonProperty("filename")]
+        public string FileName { get; set; } = string.Empty;
+
+        [JsonProperty("url")]
+        public string Url { get; set; } = string.Empty;
+
+        // Any field not explicitly declared above (custom fields, locale data, etc.)
+        [JsonExtensionData]
+        public IDictionary<string, JToken> Fields { get; set; } = new Dictionary<string, JToken>();
+    }
+}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.3.0</Version>
+    <Version>1.3.1</Version>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.3.1</Version>
+    <Version>1.4.0</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Problem

Calling `.includeEmbeddedItems().Fetch<T>()` on a model that implements
`IEntryEmbedable` throws a `JsonSerializationException` at runtime:

> Could not create an instance of type Contentstack.Utils.Interfaces.IEmbeddedObject.
> Type is an interface or abstract class and cannot be instantiated.
> Path 'entry._embedded_items.rte_json[0]._content_type_uid'

`IEntryEmbedable` declares `embeddedItems` as
`Dictionary<string, List<IEmbeddedObject>>`. When the Delivery API returns
`_embedded_items` in the response, Newtonsoft.Json tries to instantiate
`IEmbeddedObject` directly. Because it is an interface, instantiation fails.

## Changes

### `Contentstack.Utils/Models/EmbeddedObject.cs` _(new)_
Concrete class implementing both `IEmbeddedEntry` and `IEmbeddedAsset`.
Newtonsoft.Json can instantiate this in place of `IEmbeddedObject`.
`[JsonExtensionData]` on the `Fields` property preserves any custom fields
on the embedded entry or asset (e.g. `bio`, `email`, `avatar_url`) that are
not explicitly declared.

### `Contentstack.Utils/Converters/EmbeddedObjectConverter.cs` _(new)_
`JsonConverter` that intercepts `IEmbeddedObject` at deserialization time
and redirects to `EmbeddedObject`. `CanConvert` uses exact type equality
(`==`) rather than `IsAssignableFrom` so consumer-defined subclasses of
`IEmbeddedObject` are not intercepted.

## Consumer Impact

No changes required in consumer code. Models implementing `IEntryEmbedable`
continue to work as-is after the delivery SDK registers `EmbeddedObjectConverter`
in `ContentstackClient`.

## Testing

Verified with a `.includeEmbeddedItems().Fetch<T>()` call against a JSON RTE
field containing embedded entries and embedded assets:
- BEFORE: throws `JsonSerializationException`
- AFTER: deserializes successfully; `uid`, `title`, `_content_type_uid` and
  all custom fields are populated

## Changelog

See `CHANGELOG.md` → Version 1.3.1
