### PR TITLE
fix: bump package version to 2.0.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.0.1</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary
- `contentstack.utils` 2.0.0 on nuget.org was built before `EmbeddedObjectConverter`
  was added; this repo kept incrementing commits under the same 2.0.0 version,
  so the published package and source silently diverged under one version number.
- Bumps `Directory.Build.props` to 2.0.1 so the version number is unambiguous.

## Test plan
- [x] `dotnet pack` produces `contentstack.utils.2.0.1.nupkg`
- [x] Verified the packed nupkg contains `EmbeddedObjectConverter`
- [ ] Publish 2.0.1 to nuget.org (not done yet — separate step, needs confirmation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)